### PR TITLE
dependency manager return std::shared_ptr and are linked with parents

### DIFF
--- a/GameEngine/Demos/BulletImplementation/DemoScene.cpp
+++ b/GameEngine/Demos/BulletImplementation/DemoScene.cpp
@@ -122,54 +122,54 @@ bool 			DemoScene::userStart()
 			"shininess"
 		};
 
-	OpenGLTools::Shader &s = _engine.getInstance<Renderer>().addShader("MaterialBasic",
+	OpenGLTools::Shader &s = _engine.getInstance<Renderer>()->addShader("MaterialBasic",
 		"./Shaders/MaterialBasic.vp",
 		"./Shaders/MaterialBasic.fp");
 
-		_engine.getInstance<Renderer>().addUniform("MaterialBasic")
+		_engine.getInstance<Renderer>()->addUniform("MaterialBasic")
 			.init(&s, "MaterialBasic", materialBasic);
-		_engine.getInstance<Renderer>().addUniform("PerFrame")
+		_engine.getInstance<Renderer>()->addUniform("PerFrame")
 			.init(&s, "PerFrame", perFrameVars);
-		_engine.getInstance<Renderer>().addUniform("PerModel")
+		_engine.getInstance<Renderer>()->addUniform("PerModel")
 			.init(&s, "PerModel", perModelVars);
 
-	_engine.getInstance<Renderer>().addShader("basic", "Shaders/basic.vp", "Shaders/basic.fp", "Shaders/basic.gp");
-	_engine.getInstance<Renderer>().addShader("basicLight", "Shaders/light.vp", "Shaders/light.fp");
-	_engine.getInstance<Renderer>().addShader("bump", "Shaders/bump.vp", "Shaders/bump.fp");
-	_engine.getInstance<Renderer>().addShader("earth", "Shaders/earth.vp", "Shaders/earth.fp");
-	_engine.getInstance<Renderer>().addShader("fboToScreen", "Shaders/fboToScreen.vp", "Shaders/fboToScreen.fp");
-	_engine.getInstance<Renderer>().addShader("brightnessFilter", "Shaders/brightnessFilter.vp", "Shaders/brightnessFilter.fp");
-	_engine.getInstance<Renderer>().addShader("blurY", "Shaders/brightnessFilter.vp", "Shaders/blur1.fp");
+	_engine.getInstance<Renderer>()->addShader("basic", "Shaders/basic.vp", "Shaders/basic.fp", "Shaders/basic.gp");
+	_engine.getInstance<Renderer>()->addShader("basicLight", "Shaders/light.vp", "Shaders/light.fp");
+	_engine.getInstance<Renderer>()->addShader("bump", "Shaders/bump.vp", "Shaders/bump.fp");
+	_engine.getInstance<Renderer>()->addShader("earth", "Shaders/earth.vp", "Shaders/earth.fp");
+	_engine.getInstance<Renderer>()->addShader("fboToScreen", "Shaders/fboToScreen.vp", "Shaders/fboToScreen.fp");
+	_engine.getInstance<Renderer>()->addShader("brightnessFilter", "Shaders/brightnessFilter.vp", "Shaders/brightnessFilter.fp");
+	_engine.getInstance<Renderer>()->addShader("blurY", "Shaders/brightnessFilter.vp", "Shaders/blur1.fp");
 
-	_engine.getInstance<Renderer>().getShader("basic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
-	_engine.getInstance<Renderer>().getShader("basicLight")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
-	_engine.getInstance<Renderer>().getShader("bump")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(2).build();
-	_engine.getInstance<Renderer>().getShader("fboToScreen")->addTarget(GL_COLOR_ATTACHMENT0)
+	_engine.getInstance<Renderer>()->getShader("basic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
+	_engine.getInstance<Renderer>()->getShader("basicLight")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
+	_engine.getInstance<Renderer>()->getShader("bump")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(2).build();
+	_engine.getInstance<Renderer>()->getShader("fboToScreen")->addTarget(GL_COLOR_ATTACHMENT0)
 		.addLayer(GL_COLOR_ATTACHMENT0).build();
-	_engine.getInstance<Renderer>().getShader("MaterialBasic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
-	_engine.getInstance<Renderer>().getShader("earth")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
-	_engine.getInstance<Renderer>().getShader("brightnessFilter")->addTarget(GL_COLOR_ATTACHMENT1)
+	_engine.getInstance<Renderer>()->getShader("MaterialBasic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
+	_engine.getInstance<Renderer>()->getShader("earth")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
+	_engine.getInstance<Renderer>()->getShader("brightnessFilter")->addTarget(GL_COLOR_ATTACHMENT1)
 		.addLayer(GL_COLOR_ATTACHMENT0).build();
-	_engine.getInstance<Renderer>().getShader("blurY")->addTarget(GL_COLOR_ATTACHMENT2)
+	_engine.getInstance<Renderer>()->getShader("blurY")->addTarget(GL_COLOR_ATTACHMENT2)
 		.addLayer(GL_COLOR_ATTACHMENT0).addLayer(GL_COLOR_ATTACHMENT1).build();
 
-	_engine.getInstance<Renderer>().getUniform("PerFrame")->setUniform("light", glm::vec4(0, 0, 0, 1));
+	_engine.getInstance<Renderer>()->getUniform("PerFrame")->setUniform("light", glm::vec4(0, 0, 0, 1));
 
-	_engine.getInstance<Renderer>().bindShaderToUniform("basicLight", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basicLight", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basicLight", "MaterialBasic", "MaterialBasic");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basic", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basic", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basic", "MaterialBasic", "MaterialBasic");
-	_engine.getInstance<Renderer>().bindShaderToUniform("earth", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("earth", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("earth", "MaterialBasic", "MaterialBasic");
-	_engine.getInstance<Renderer>().bindShaderToUniform("bump", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("bump", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("bump", "MaterialBasic", "MaterialBasic");
-	_engine.getInstance<Renderer>().bindShaderToUniform("MaterialBasic", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("MaterialBasic", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("MaterialBasic", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basicLight", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basicLight", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basicLight", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basic", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basic", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basic", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("earth", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("earth", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("earth", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("bump", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("bump", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("bump", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("MaterialBasic", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("MaterialBasic", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("MaterialBasic", "MaterialBasic", "MaterialBasic");
 
 
 	AMediaFile::loadFromList("./Assets/Serialized/export__cube.cpd");
@@ -179,10 +179,10 @@ bool 			DemoScene::userStart()
 	AMediaFile::loadFromList("./Assets/Serialized/export__galileo.cpd");
 //	AMediaFile::loadFromList("./Assets/Serialized/export__Museum.cpd");
 
-	_engine.getInstance<AudioManager>().loadSound(File("./Assets/switch19.wav"), Audio::AudioSpatialType::AUDIO_3D);
-	_engine.getInstance<AudioManager>().loadStream(File("./Assets/isolee.mp3"), Audio::AudioSpatialType::AUDIO_3D);
-	_engine.getInstance<AudioManager>().loadSound(File("./Assets/arriveOnFloor.mp3"), Audio::AudioSpatialType::AUDIO_3D);
-	_engine.getInstance<AudioManager>().loadSound(File("./Assets/jump.mp3"), Audio::AudioSpatialType::AUDIO_3D);
+	_engine.getInstance<AudioManager>()->loadSound(File("./Assets/switch19.wav"), Audio::AudioSpatialType::AUDIO_3D);
+	_engine.getInstance<AudioManager>()->loadStream(File("./Assets/isolee.mp3"), Audio::AudioSpatialType::AUDIO_3D);
+	_engine.getInstance<AudioManager>()->loadSound(File("./Assets/arriveOnFloor.mp3"), Audio::AudioSpatialType::AUDIO_3D);
+	_engine.getInstance<AudioManager>()->loadSound(File("./Assets/jump.mp3"), Audio::AudioSpatialType::AUDIO_3D);
 
 	// EXAMPLE: HOW TO CREATE A MEDIA FILE DYNAMICALY
 	auto defaultBallMesh = AMediaFile::get<ObjFile>("obj__ball");
@@ -232,8 +232,8 @@ bool 			DemoScene::userStart()
 		character->addComponent<Component::FirstPersonView>();
 		e->addComponent<Component::AudioListener>();
 		auto ae = e->addComponent<Component::AudioEmitter>();
-		auto arriveOnFloor = _engine.getInstance<AudioManager>().getAudio("arriveOnFloor");
-		auto jump = _engine.getInstance<AudioManager>().getAudio("jump");
+		auto arriveOnFloor = _engine.getInstance<AudioManager>()->getAudio("arriveOnFloor");
+		auto jump = _engine.getInstance<AudioManager>()->getAudio("jump");
 		ae->setAudio(arriveOnFloor, "arriveOnFloor", CHANNEL_GROUP_EFFECT);
 		ae->setAudio(jump, "jump", CHANNEL_GROUP_EFFECT);
 	}
@@ -244,7 +244,7 @@ bool 			DemoScene::userStart()
 		rigidbody->getBody().getBroadphaseHandle()->m_collisionFilterGroup = COLLISION_LAYER_STATIC | COLLISION_LAYER_DYNAMIC;
 		rigidbody->getBody().getBroadphaseHandle()->m_collisionFilterMask = COLLISION_LAYER_DYNAMIC;
 		auto audioCpt = e->addComponent<Component::AudioEmitter>();
-		audioCpt->setAudio(_engine.getInstance<AudioManager>().getAudio("isolee"), "ambiant", CHANNEL_GROUP_MUSIC);
+		audioCpt->setAudio(_engine.getInstance<AudioManager>()->getAudio("isolee"), "ambiant", CHANNEL_GROUP_MUSIC);
 		audioCpt->play("ambiant", true);
 
 	}
@@ -259,14 +259,14 @@ bool 			DemoScene::userStart()
 		"view"
 	};
 
-	OpenGLTools::Shader &sky = _engine.getInstance<Renderer>().addShader("cubemapShader", "Shaders/cubemap.vp", "Shaders/cubemap.fp");
+	OpenGLTools::Shader &sky = _engine.getInstance<Renderer>()->addShader("cubemapShader", "Shaders/cubemap.vp", "Shaders/cubemap.fp");
 
-	_engine.getInstance<Renderer>().getShader("cubemapShader")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
+	_engine.getInstance<Renderer>()->getShader("cubemapShader")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
 
-	_engine.getInstance<Renderer>().addUniform("cameraUniform").
+	_engine.getInstance<Renderer>()->addUniform("cameraUniform").
 		init(&sky, "cameraUniform", vars);
 	
-	_engine.getInstance<Renderer>().bindShaderToUniform("cubemapShader", "cameraUniform", "cameraUniform");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("cubemapShader", "cameraUniform", "cameraUniform");
 
 	cameraComponent->attachSkybox("skybox__space", "cubemapShader");
 	return (true);
@@ -276,11 +276,11 @@ bool 			DemoScene::userUpdate(double time)
 {
 	static std::queue<Entity> stack;
 
-	if (_engine.getInstance<Input>().getInput(SDL_BUTTON_RIGHT))
+	if (_engine.getInstance<Input>()->getInput(SDL_BUTTON_RIGHT))
 	{
 		glm::vec3 from, to;
 		getSystem<CameraSystem>()->getRayFromCenterOfScreen(from, to);
-		auto test = _engine.getInstance<BulletCollisionManager>().rayCast(from, from + to * 1000.0f);
+		auto test = _engine.getInstance<BulletCollisionManager>()->rayCast(from, from + to * 1000.0f);
 		if (test.size() != 0)
 		{
 			for (auto e : test)
@@ -291,7 +291,7 @@ bool 			DemoScene::userUpdate(double time)
 		}
 	}
 	static float delay = 0.0f;
-	if (_engine.getInstance<Input>().getInput(SDL_BUTTON_LEFT) && delay <= 0.0f)
+	if (_engine.getInstance<Input>()->getInput(SDL_BUTTON_LEFT) && delay <= 0.0f)
 	{
 		glm::vec3 from, to;
 		getSystem<CameraSystem>()->getRayFromCenterOfScreen(from, to);
@@ -300,7 +300,7 @@ bool 			DemoScene::userUpdate(double time)
 		rigidbody->getBody().applyCentralImpulse(convertGLMVectorToBullet(to * 10.0f));
 		rigidbody->getBody().getBroadphaseHandle()->m_collisionFilterGroup = COLLISION_LAYER_STATIC | COLLISION_LAYER_DYNAMIC;
 		rigidbody->getBody().getBroadphaseHandle()->m_collisionFilterMask = COLLISION_LAYER_DYNAMIC;
-		e->addComponent<Component::AudioEmitter>()->setAudio(_engine.getInstance<AudioManager>().getAudio("switch19"), "collision", CHANNEL_GROUP_EFFECT);
+		e->addComponent<Component::AudioEmitter>()->setAudio(_engine.getInstance<AudioManager>()->getAudio("switch19"), "collision", CHANNEL_GROUP_EFFECT);
 		e->addTag(BALL_TAG);
 		if (stack.size() > 300)
 		{
@@ -312,8 +312,8 @@ bool 			DemoScene::userUpdate(double time)
 	}
 	if (delay >= 0.0f)
 		delay -= time;
-	if (_engine.getInstance<Input>().getInput(SDLK_ESCAPE) ||
-		_engine.getInstance<Input>().getInput(SDL_QUIT))
+	if (_engine.getInstance<Input>()->getInput(SDLK_ESCAPE) ||
+		_engine.getInstance<Input>()->getInput(SDL_QUIT))
 		return (false);
 	return (true);
 }

--- a/GameEngine/Demos/BulletImplementation/Main.cpp
+++ b/GameEngine/Demos/BulletImplementation/Main.cpp
@@ -32,20 +32,20 @@ int			main(int ac, char **av)
 	e.setInstance<AssetsManager>();
 	e.setInstance<Renderer>(&e);
 	e.setInstance<SceneManager>();
-	e.setInstance<BulletDynamicManager, BulletCollisionManager>().init();
-	e.setInstance<AudioManager>().init();
+	e.setInstance<BulletDynamicManager, BulletCollisionManager>()->init();
+	e.setInstance<AudioManager>()->init();
 
 	// init engine
 	if (e.init() == false)
 		return (EXIT_FAILURE);
 
 	// add scene
-	e.getInstance<SceneManager>().addScene(new DemoScene(e), "demo");
+	e.getInstance<SceneManager>()->addScene(new DemoScene(e), "demo");
 
 	// bind scene
-	if (!e.getInstance<SceneManager>().initScene("demo"))
+	if (!e.getInstance<SceneManager>()->initScene("demo"))
 		return false;
-	e.getInstance<SceneManager>().enableScene("demo", 0);
+	e.getInstance<SceneManager>()->enableScene("demo", 0);
 
 
 	// lanch engine

--- a/GameEngine/Demos/SolarSystem/DemoScene.cpp
+++ b/GameEngine/Demos/SolarSystem/DemoScene.cpp
@@ -105,53 +105,53 @@ bool 			DemoScene::userStart()
 			"shininess"
 		};
 
-	OpenGLTools::Shader &s = _engine.getInstance<Renderer>().addShader("MaterialBasic",
+	OpenGLTools::Shader &s = _engine.getInstance<Renderer>()->addShader("MaterialBasic",
 		"./Shaders/MaterialBasic.vp",
 		"./Shaders/MaterialBasic.fp");
 
-		_engine.getInstance<Renderer>().addUniform("MaterialBasic")
+		_engine.getInstance<Renderer>()->addUniform("MaterialBasic")
 			.init(&s, "MaterialBasic", materialBasic);
-		_engine.getInstance<Renderer>().addUniform("PerFrame")
+		_engine.getInstance<Renderer>()->addUniform("PerFrame")
 			.init(&s, "PerFrame", perFrameVars);
-		_engine.getInstance<Renderer>().addUniform("PerModel")
+		_engine.getInstance<Renderer>()->addUniform("PerModel")
 			.init(&s, "PerModel", perModelVars);
 
-	_engine.getInstance<Renderer>().addShader("earth", "./Shaders/earth.vp", "./Shaders/earth.fp");
-	_engine.getInstance<Renderer>().addShader("basic", "Shaders/basic.vp", "Shaders/basic.fp", "Shaders/tesselation.gp");
-	_engine.getInstance<Renderer>().addShader("basicLight", "Shaders/light.vp", "Shaders/light.fp");
-	_engine.getInstance<Renderer>().addShader("bump", "Shaders/bump.vp", "Shaders/bump.fp");
-	_engine.getInstance<Renderer>().addShader("fboToScreen", "Shaders/fboToScreen.vp", "Shaders/fboToScreen.fp");
-	_engine.getInstance<Renderer>().addShader("brightnessFilter", "Shaders/brightnessFilter.vp", "Shaders/brightnessFilter.fp");
-	_engine.getInstance<Renderer>().addShader("blurY", "Shaders/brightnessFilter.vp", "Shaders/blur1.fp");
-	_engine.getInstance<Renderer>().getShader("MaterialBasic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
-	_engine.getInstance<Renderer>().getShader("basic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
-	_engine.getInstance<Renderer>().getShader("basicLight")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
-	_engine.getInstance<Renderer>().getShader("bump")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(2).build();
-	_engine.getInstance<Renderer>().getShader("fboToScreen")->addTarget(GL_COLOR_ATTACHMENT0)
+	_engine.getInstance<Renderer>()->addShader("earth", "./Shaders/earth.vp", "./Shaders/earth.fp");
+	_engine.getInstance<Renderer>()->addShader("basic", "Shaders/basic.vp", "Shaders/basic.fp", "Shaders/tesselation.gp");
+	_engine.getInstance<Renderer>()->addShader("basicLight", "Shaders/light.vp", "Shaders/light.fp");
+	_engine.getInstance<Renderer>()->addShader("bump", "Shaders/bump.vp", "Shaders/bump.fp");
+	_engine.getInstance<Renderer>()->addShader("fboToScreen", "Shaders/fboToScreen.vp", "Shaders/fboToScreen.fp");
+	_engine.getInstance<Renderer>()->addShader("brightnessFilter", "Shaders/brightnessFilter.vp", "Shaders/brightnessFilter.fp");
+	_engine.getInstance<Renderer>()->addShader("blurY", "Shaders/brightnessFilter.vp", "Shaders/blur1.fp");
+	_engine.getInstance<Renderer>()->getShader("MaterialBasic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
+	_engine.getInstance<Renderer>()->getShader("basic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
+	_engine.getInstance<Renderer>()->getShader("basicLight")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
+	_engine.getInstance<Renderer>()->getShader("bump")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(2).build();
+	_engine.getInstance<Renderer>()->getShader("fboToScreen")->addTarget(GL_COLOR_ATTACHMENT0)
 		.addLayer(GL_COLOR_ATTACHMENT0).build();
-	_engine.getInstance<Renderer>().getShader("earth")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
-	_engine.getInstance<Renderer>().getShader("brightnessFilter")->addTarget(GL_COLOR_ATTACHMENT1)
+	_engine.getInstance<Renderer>()->getShader("earth")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
+	_engine.getInstance<Renderer>()->getShader("brightnessFilter")->addTarget(GL_COLOR_ATTACHMENT1)
 		.addLayer(GL_COLOR_ATTACHMENT0).build();
-	_engine.getInstance<Renderer>().getShader("blurY")->addTarget(GL_COLOR_ATTACHMENT2)
+	_engine.getInstance<Renderer>()->getShader("blurY")->addTarget(GL_COLOR_ATTACHMENT2)
 		.addLayer(GL_COLOR_ATTACHMENT0).addLayer(GL_COLOR_ATTACHMENT1).build();
 
-	_engine.getInstance<Renderer>().getUniform("PerFrame")->setUniform("light", glm::vec4(0, 0, 0, 1));
+	_engine.getInstance<Renderer>()->getUniform("PerFrame")->setUniform("light", glm::vec4(0, 0, 0, 1));
 
-	_engine.getInstance<Renderer>().bindShaderToUniform("basicLight", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basicLight", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basicLight", "MaterialBasic", "MaterialBasic");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basic", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basic", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("basic", "MaterialBasic", "MaterialBasic");
-	_engine.getInstance<Renderer>().bindShaderToUniform("earth", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("earth", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("earth", "MaterialBasic", "MaterialBasic");
-	_engine.getInstance<Renderer>().bindShaderToUniform("bump", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("bump", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("bump", "MaterialBasic", "MaterialBasic");
-	_engine.getInstance<Renderer>().bindShaderToUniform("MaterialBasic", "PerFrame", "PerFrame");
-	_engine.getInstance<Renderer>().bindShaderToUniform("MaterialBasic", "PerModel", "PerModel");
-	_engine.getInstance<Renderer>().bindShaderToUniform("MaterialBasic", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basicLight", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basicLight", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basicLight", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basic", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basic", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("basic", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("earth", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("earth", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("earth", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("bump", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("bump", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("bump", "MaterialBasic", "MaterialBasic");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("MaterialBasic", "PerFrame", "PerFrame");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("MaterialBasic", "PerModel", "PerModel");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("MaterialBasic", "MaterialBasic", "MaterialBasic");
 
 	std::string		vars[] = 
 	{
@@ -159,19 +159,19 @@ bool 			DemoScene::userStart()
 		"view"
 	};
 
-	OpenGLTools::Shader &sky = _engine.getInstance<Renderer>().addShader("cubemapShader", "Shaders/cubemap.vp", "Shaders/cubemap.fp");
+	OpenGLTools::Shader &sky = _engine.getInstance<Renderer>()->addShader("cubemapShader", "Shaders/cubemap.vp", "Shaders/cubemap.fp");
 
-	_engine.getInstance<Renderer>().getShader("cubemapShader")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
+	_engine.getInstance<Renderer>()->getShader("cubemapShader")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
 
-	_engine.getInstance<Renderer>().addUniform("cameraUniform").
+	_engine.getInstance<Renderer>()->addUniform("cameraUniform").
 		init(&sky, "cameraUniform", vars);
 
-	_engine.getInstance<Renderer>().bindShaderToUniform("cubemapShader", "cameraUniform", "cameraUniform");
+	_engine.getInstance<Renderer>()->bindShaderToUniform("cubemapShader", "cameraUniform", "cameraUniform");
 
 
 	AMediaFile::loadFromList("./Assets/Serialized/export__ball.cpd");
 	AMediaFile::loadFromList("./Assets/Serialized/export__Space.cpd");
-	auto music = _engine.getInstance<AudioManager>().loadStream(File("./Assets/isolee.mp3"), Audio::AudioSpatialType::AUDIO_3D);
+	auto music = _engine.getInstance<AudioManager>()->loadStream(File("./Assets/isolee.mp3"), Audio::AudioSpatialType::AUDIO_3D);
 
 
 	// SERIALIZATION
@@ -261,8 +261,8 @@ bool 			DemoScene::userStart()
 
 bool 			DemoScene::userUpdate(double time)
 {
-	if (_engine.getInstance<Input>().getInput(SDLK_ESCAPE) ||
-		_engine.getInstance<Input>().getInput(SDL_QUIT))
+	if (_engine.getInstance<Input>()->getInput(SDLK_ESCAPE) ||
+		_engine.getInstance<Input>()->getInput(SDL_QUIT))
 	{
 		 //SERIALIZATION
 		{

--- a/GameEngine/Demos/SolarSystem/Main.cpp
+++ b/GameEngine/Demos/SolarSystem/Main.cpp
@@ -33,7 +33,7 @@ int			main(int ac, char **av)
 	e.setInstance<AssetsManager>();
 	e.setInstance<Renderer>(&e);
 	e.setInstance<SceneManager>();
-	if (!e.setInstance<AudioManager>().init())
+	if (!e.setInstance<AudioManager>()->init())
 		return EXIT_FAILURE;
 
 	// init engine
@@ -42,12 +42,12 @@ int			main(int ac, char **av)
 
 
 	// add scene
-	e.getInstance<SceneManager>().addScene(new DemoScene(e), "demo");
+	e.getInstance<SceneManager>()->addScene(new DemoScene(e), "demo");
 
 	// bind scene
-	if (!e.getInstance<SceneManager>().initScene("demo"))
+	if (!e.getInstance<SceneManager>()->initScene("demo"))
 		return false;
-	e.getInstance<SceneManager>().enableScene("demo", 0);
+	e.getInstance<SceneManager>()->enableScene("demo", 0);
 
 	// launch engine
 	if (e.start() == false)

--- a/GameEngine/Demos/SpaceShooter/InGameScene.hpp
+++ b/GameEngine/Demos/SpaceShooter/InGameScene.hpp
@@ -76,22 +76,22 @@ public:
 		};
 
 
-		OpenGLTools::Shader &s = _engine.getInstance<Renderer>().addShader("MaterialBasic",
+		OpenGLTools::Shader &s = _engine.getInstance<Renderer>()->addShader("MaterialBasic",
 			"./Shaders/MaterialBasic.vp",
 			"./Shaders/MaterialBasic.fp");
 
-		_engine.getInstance<Renderer>().addUniform("MaterialBasic")
+		_engine.getInstance<Renderer>()->addUniform("MaterialBasic")
 			.init(&s, "MaterialBasic", materialBasic);
-		_engine.getInstance<Renderer>().addUniform("PerFrame")
+		_engine.getInstance<Renderer>()->addUniform("PerFrame")
 			.init(&s, "PerFrame", perFrameVars);
-		_engine.getInstance<Renderer>().addUniform("PerModel")
+		_engine.getInstance<Renderer>()->addUniform("PerModel")
 			.init(&s, "PerModel", perModelVars);
 
-		_engine.getInstance<Renderer>().getShader("MaterialBasic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
-		_engine.getInstance<Renderer>().getUniform("PerFrame")->setUniform("light", glm::vec4(0, 0, 0, 1));
-		_engine.getInstance<Renderer>().bindShaderToUniform("MaterialBasic", "PerFrame", "PerFrame");
-		_engine.getInstance<Renderer>().bindShaderToUniform("MaterialBasic", "PerModel", "PerModel");
-		_engine.getInstance<Renderer>().bindShaderToUniform("MaterialBasic", "MaterialBasic", "MaterialBasic");
+		_engine.getInstance<Renderer>()->getShader("MaterialBasic")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(4).build();
+		_engine.getInstance<Renderer>()->getUniform("PerFrame")->setUniform("light", glm::vec4(0, 0, 0, 1));
+		_engine.getInstance<Renderer>()->bindShaderToUniform("MaterialBasic", "PerFrame", "PerFrame");
+		_engine.getInstance<Renderer>()->bindShaderToUniform("MaterialBasic", "PerModel", "PerModel");
+		_engine.getInstance<Renderer>()->bindShaderToUniform("MaterialBasic", "MaterialBasic", "MaterialBasic");
 
 		AMediaFile::loadFromList("./Assets/Serialized/export__cube.cpd");
 		AMediaFile::loadFromList("./Assets/Serialized/export__ball.cpd");
@@ -105,11 +105,11 @@ public:
 			"view"
 		};
 
-		OpenGLTools::Shader &sky = _engine.getInstance<Renderer>().addShader("cubemapShader", "Shaders/cubemap.vp", "Shaders/cubemap.fp");
-		_engine.getInstance<Renderer>().getShader("cubemapShader")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
-		_engine.getInstance<Renderer>().addUniform("cameraUniform").
+		OpenGLTools::Shader &sky = _engine.getInstance<Renderer>()->addShader("cubemapShader", "Shaders/cubemap.vp", "Shaders/cubemap.fp");
+		_engine.getInstance<Renderer>()->getShader("cubemapShader")->addTarget(GL_COLOR_ATTACHMENT0).setTextureNumber(1).build();
+		_engine.getInstance<Renderer>()->addUniform("cameraUniform").
 			init(&sky, "cameraUniform", vars);
-		_engine.getInstance<Renderer>().bindShaderToUniform("cubemapShader", "cameraUniform", "cameraUniform");
+		_engine.getInstance<Renderer>()->bindShaderToUniform("cubemapShader", "cameraUniform", "cameraUniform");
 
 
 		/////////////////////////////
@@ -186,31 +186,31 @@ public:
 	{
 		static std::vector<Entity> balls;
 
-		if (_engine.getInstance<Input>().getInput(SDLK_ESCAPE) ||
-			_engine.getInstance<Input>().getInput(SDL_QUIT))
+		if (_engine.getInstance<Input>()->getInput(SDLK_ESCAPE) ||
+			_engine.getInstance<Input>()->getInput(SDL_QUIT))
 			return (false);
 		static auto timer = 0.0f;
 
-		if (_engine.getInstance<Input>().getInput(SDLK_d))
+		if (_engine.getInstance<Input>()->getInput(SDLK_d))
 		{
 			for (auto &e : balls)
 				destroy(e);
 			balls.clear();
 		}
 
-		if (_engine.getInstance<Input>().getInput(SDLK_u))
+		if (_engine.getInstance<Input>()->getInput(SDLK_u))
 		{
 			test->setLocalTransform() = glm::scale(test->getLocalTransform(), glm::vec3(0.9));
 			test->computeTransformAndUpdateGraphnode();
 		}
 
-		if (_engine.getInstance<Input>().getInput(SDLK_i))
+		if (_engine.getInstance<Input>()->getInput(SDLK_i))
 		{
 			test->setLocalTransform() = glm::scale(test->getLocalTransform(), glm::vec3(1.1));
 			test->computeTransformAndUpdateGraphnode();
 		}
 
-		if (_engine.getInstance<Input>().getInput(SDLK_r) && timer <= 0.0f)
+		if (_engine.getInstance<Input>()->getInput(SDLK_r) && timer <= 0.0f)
 		{
 			timer = 0.3f;
 			for (auto i = 0; i < 10; ++i)

--- a/GameEngine/Demos/SpaceShooter/Main.cpp
+++ b/GameEngine/Demos/SpaceShooter/Main.cpp
@@ -32,19 +32,19 @@ int			main(int ac, char **av)
 	e.setInstance<Renderer>(&e);
 	e.setInstance<SceneManager>();
 //	e.setInstance<BulletCollisionManager>().init();
-	e.setInstance<BulletDynamicManager, BulletCollisionManager>().init();
+	e.setInstance<BulletDynamicManager, BulletCollisionManager>()->init();
 
 	// init engine
 	if (e.init() == false)
 		return (EXIT_FAILURE);
 
 	// add scene
-	e.getInstance<SceneManager>().addScene(new InGameScene(e), "InGameScene");
+	e.getInstance<SceneManager>()->addScene(new InGameScene(e), "InGameScene");
 
 	// bind scene
-	if (!e.getInstance<SceneManager>().initScene("InGameScene"))
+	if (!e.getInstance<SceneManager>()->initScene("InGameScene"))
 		return false;
-	e.getInstance<SceneManager>().enableScene("InGameScene", 100);
+	e.getInstance<SceneManager>()->enableScene("InGameScene", 100);
 
 	// launch engine
 	if (e.start() == false)

--- a/GameEngine/Demos/SpaceShooter/Systems/SpaceshipControllerSystem.hpp
+++ b/GameEngine/Demos/SpaceShooter/Systems/SpaceshipControllerSystem.hpp
@@ -46,12 +46,12 @@ private:
 	void updateComponent(Entity &entity, std::shared_ptr<Component::SpaceshipController> c, double time)
 	{
 			c->resetControls();
-			auto &inputs = _scene->getEngine().getInstance<Input>();
+			auto inputs = _scene->getInstance<Input>();
 			auto &controls = c->controls;
 			auto &keys = c->keys;
 
-			float yAngle = inputs.getMouseDelta().y * 0.3f;
-			float xAngle = - inputs.getMouseDelta().x * 0.3f;
+			float yAngle = inputs->getMouseDelta().y * 0.3f;
+			float xAngle = - inputs->getMouseDelta().x * 0.3f;
 
 			entity->setLocalTransform() = glm::rotate(entity->getLocalTransform(), yAngle, glm::vec3(1, 0, 0));
 			entity->setLocalTransform() = glm::rotate(entity->getLocalTransform(), xAngle, glm::vec3(0, 1, 0));
@@ -59,7 +59,7 @@ private:
 			// UPDATE KEYS
 			for (unsigned int i = 0; i < controls.size(); ++i)
 			{
-				controls[i] = inputs.getKey(keys[i]);
+				controls[i] = inputs->getKey(keys[i]);
 			}
 
 			auto forwardDir = glm::vec3(0,0,1);
@@ -94,7 +94,7 @@ private:
 				balls.push_back(b);
 				b->computeTransformAndUpdateGraphnode();
 			}
-			if (inputs.getKey(SDLK_p))
+			if (inputs->getKey(SDLK_p))
 			{
 				for (auto e : balls)
 					_scene->destroy(e);

--- a/GameEngine/Demos/SpaceShooter/Systems/VelocitySystem.hpp
+++ b/GameEngine/Demos/SpaceShooter/Systems/VelocitySystem.hpp
@@ -30,7 +30,7 @@ private:
 
 	virtual void mainUpdate(double time)
 	{
-		auto totalTime = _scene->getEngine().getInstance<Timer>().getElapsed();
+		auto totalTime = _scene->getEngine().getInstance<Timer>()->getElapsed();
 		for (auto e : _filter.getCollection())
 		{
 			auto velocity = e->getComponent<Component::Velocity>();

--- a/GameEngine/GameEngine/Engine/Audio/Audio.cpp
+++ b/GameEngine/GameEngine/Engine/Audio/Audio.cpp
@@ -1,7 +1,7 @@
 #include <Audio/Audio.hh>
 #include <Audio/AudioManager.hh>
 
-Audio::Audio(AudioManager *manager, const File &file, AudioType type, const std::string &name)
+Audio::Audio(std::shared_ptr<AudioManager> manager, const File &file, AudioType type, const std::string &name)
 : _manager(manager)
 , _file(file)
 , _name(name.empty() ? file.getShortFileName() : name)
@@ -23,22 +23,28 @@ bool Audio::load(AudioSpatialType type)
 {
 	if (_audio)
 		return true;
+	FMOD::Sound *audio;
 	if (_audioType == AUDIO_SOUND)
 	{
-		_manager->getSystem()->createSound(_file.getFullName().c_str(), type, 0, &_audio);
+		_manager->getSystem()->createSound(_file.getFullName().c_str(), type, 0, &audio);
 	}
 	else if (_audioType == AUDIO_STREAM)
 	{
-		_manager->getSystem()->createStream(_file.getFullName().c_str(), type, 0, &_audio);
+		_manager->getSystem()->createStream(_file.getFullName().c_str(), type, 0, &audio);
 	}
-	assert(_audio != nullptr && "FMOD failed to load audio.");
+	if (audio == nullptr)
+	{
+		std::cerr << "FMOD failed to load audio." << std::endl;
+		return false;
+	}
+	_audio = std::shared_ptr<FMOD::Sound>(audio);
 	return true;
 }
 
 FMOD::Channel *Audio::play(ChannelGroupType channelGroup, bool now)
 {
 	FMOD::Channel *channel = nullptr;
-	_manager->getSystem()->playSound(FMOD_CHANNEL_FREE, _audio, true, &channel);
+	_manager->getSystem()->playSound(FMOD_CHANNEL_FREE, _audio.get(), true, &channel);
 	channel->setChannelGroup(_manager->getChannelGroup(channelGroup));
 	channel->setPaused(!now);
 	return channel;

--- a/GameEngine/GameEngine/Engine/Audio/Audio.hh
+++ b/GameEngine/GameEngine/Engine/Audio/Audio.hh
@@ -27,14 +27,14 @@ public:
 	};
 
 public:
-	Audio(AudioManager *manager, const File &file, AudioType type, const std::string &name = "");
+	Audio(std::shared_ptr<AudioManager> manager, const File &file, AudioType type, const std::string &name = "");
 	~Audio();
 	bool load(AudioSpatialType type);
 	FMOD::Channel *play(ChannelGroupType channelGroup, bool now);
 private:
-	AudioManager *_manager;
+	std::shared_ptr<AudioManager> _manager;
 	File _file;
 	const std::string _name;
-	FMOD::Sound *_audio;
+	std::shared_ptr<FMOD::Sound> _audio;
 	AudioType _audioType;
 };

--- a/GameEngine/GameEngine/Engine/Audio/AudioManager.cpp
+++ b/GameEngine/GameEngine/Engine/Audio/AudioManager.cpp
@@ -1,5 +1,6 @@
 #include <Audio/AudioManager.hh>
 #include <cassert>
+#include <iostream>
 
 AudioManager::AudioManager()
 : _system(nullptr)
@@ -106,10 +107,11 @@ std::shared_ptr<Audio> AudioManager::loadSound(const File &file, Audio::AudioSpa
 	std::string tname = name.empty() ? file.getShortFileName() : name;
 	if (_audios.find(tname) != std::end(_audios))
 		return _audios[name];
-	std::shared_ptr<Audio> audio{ new Audio(this, file, Audio::AudioType::AUDIO_SOUND, name) };
+
+	std::shared_ptr<Audio> audio{ new Audio(shared_from_this(), file, Audio::AudioType::AUDIO_SOUND, name) };
 	if (!audio->load(spacialType))
 	{
-		//			std::cerr << "Audio load failed : " << tname << std::endl;
+//		std::cout << "Audio load failed : " << tname << std::endl;
 		return nullptr;
 	}
 	_audios.insert(std::make_pair(tname, audio));
@@ -121,10 +123,10 @@ std::shared_ptr<Audio> AudioManager::loadStream(const File &file, Audio::AudioSp
 	std::string tname = name.empty() ? file.getShortFileName() : name;
 	if (_audios.find(tname) != std::end(_audios))
 		return _audios[name];
-	std::shared_ptr<Audio> audio{ new Audio(this, file, Audio::AudioType::AUDIO_STREAM, name) };
+	std::shared_ptr<Audio> audio{ new Audio(shared_from_this() , file, Audio::AudioType::AUDIO_STREAM, name) };
 	if (!audio->load(spacialType))
 	{
-		//			std::cerr << "Audio load failed : " << tname << std::endl;
+//		std::cout << "Audio load failed : " << tname << std::endl;
 		return nullptr;
 	}
 	_audios.insert(std::make_pair(tname, audio));

--- a/GameEngine/GameEngine/Engine/Audio/AudioManager.hh
+++ b/GameEngine/GameEngine/Engine/Audio/AudioManager.hh
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <Audio/Audio.hh>
 
-class AudioManager : public Dependency
+class AudioManager : public std::enable_shared_from_this<AudioManager>, public Dependency
 {
 public:
 	AudioManager();

--- a/GameEngine/GameEngine/Engine/Components/AudioEmitter.cpp
+++ b/GameEngine/GameEngine/Engine/Components/AudioEmitter.cpp
@@ -48,7 +48,7 @@ void AudioEmitter::reset()
 
 void AudioEmitter::clearAllAudios()
 {
-	for (auto &&e : audios)
+	for (auto &e : audios)
 		e.second.channel->stop();
 	audios.clear();
 }

--- a/GameEngine/GameEngine/Engine/Components/MeshRenderer.cpp
+++ b/GameEngine/GameEngine/Engine/Components/MeshRenderer.cpp
@@ -36,9 +36,9 @@ namespace Component
 
 	void MeshRenderer::render()
 	{
-		OpenGLTools::UniformBuffer *perModelUniform = _entity->getScene()->getEngine().getInstance<Renderer>().getUniform("PerModel");
-		OpenGLTools::UniformBuffer *materialUniform = _entity->getScene()->getEngine().getInstance<Renderer>().getUniform("MaterialBasic");
-		auto s = _entity->getScene()->getEngine().getInstance<Renderer>().getShader(shader);
+		OpenGLTools::UniformBuffer *perModelUniform = _entity->getScene()->getEngine().getInstance<Renderer>()->getUniform("PerModel");
+		OpenGLTools::UniformBuffer *materialUniform = _entity->getScene()->getEngine().getInstance<Renderer>()->getUniform("MaterialBasic");
+		auto s = _entity->getScene()->getEngine().getInstance<Renderer>()->getShader(shader);
 		if (s)
 			s->use();
 		perModelUniform->setUniform("model", _entity->getGlobalTransform());

--- a/GameEngine/GameEngine/Engine/Core/AScene.cpp
+++ b/GameEngine/GameEngine/Engine/Core/AScene.cpp
@@ -6,7 +6,8 @@
 #include <Systems/System.h>
 
 AScene::AScene(Engine &engine) :
-	_engine(engine)
+DependenciesInjector(&engine),
+_engine(engine)
 {
 	setInstance<PubSub::Manager>();
 }

--- a/GameEngine/GameEngine/Engine/Core/Engine.cpp
+++ b/GameEngine/GameEngine/Engine/Core/Engine.cpp
@@ -20,9 +20,9 @@ Engine::~Engine()
 
 bool        Engine::init()
 {
-	auto &context = getInstance<IRenderContext>();
+	auto context = getInstance<IRenderContext>();
 
-	if (!context.start(1920, 1080, "Mini solar system"))
+	if (!context->start(1920, 1080, "Mini solar system"))
 		return (false);
 
 	if (glewInit() != GLEW_OK)
@@ -30,7 +30,7 @@ bool        Engine::init()
 		std::cerr << "glewInit Failed" << std::endl;
 		return (false);
 	}
-	if (!getInstance<Renderer>().init())
+	if (!getInstance<Renderer>()->init())
 		return false;
   	glClearColor(0, 0, 0, 1);
 	glEnable(GL_DEPTH_TEST);
@@ -52,26 +52,26 @@ bool 		Engine::update()
 
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-	auto &timer = getInstance<Timer>();
-	auto &inputs = getInstance<Input>();
-	auto &sceneManager = getInstance<SceneManager>();
-	auto time = timer.getElapsed();
+	auto timer = getInstance<Timer>();
+	auto inputs = getInstance<Input>();
+	auto sceneManager = getInstance<SceneManager>();
+	auto time = timer->getElapsed();
 
-	timer.update();
-    inputs.clearInputs();
-	context.updateEvents(inputs);
-	sceneManager.update(time);
+	timer->update();
+    inputs->clearInputs();
+	context->updateEvents(*inputs.get());
+	sceneManager->update(time);
 
-	context.flush();
+	context->flush();
 
-	return (sceneManager.userUpdate(time));
+	return (sceneManager->userUpdate(time));
 }
 
 void 		Engine::stop()
 {
-	static auto &renderer = getInstance<Renderer>();
-	auto &context = getInstance<IRenderContext>();
+	auto renderer = getInstance<Renderer>();
+	auto context = getInstance<IRenderContext>();
 
-	renderer.uninit();
-	context.stop();
+	renderer->uninit();
+	context->stop();
 }

--- a/GameEngine/GameEngine/Engine/Systems/AudioSystem.hpp
+++ b/GameEngine/GameEngine/Engine/Systems/AudioSystem.hpp
@@ -16,7 +16,7 @@ public:
 		: System(scene)
 		, _emitters(scene)
 		, _listeners(scene)
-		, _manager(&scene->getEngine().getInstance<AudioManager>())
+		, _manager(scene->getInstance<AudioManager>())
 	{
 		assert(_manager != nullptr && "No audio manager found.");
 	}
@@ -24,7 +24,7 @@ public:
 protected:
 	EntityFilter _emitters;
 	EntityFilter _listeners;
-	AudioManager *_manager;
+	std::shared_ptr<AudioManager> _manager;
 
 	virtual void updateBegin(double time)
 	{}

--- a/GameEngine/GameEngine/Engine/Systems/CameraSystem.hpp
+++ b/GameEngine/GameEngine/Engine/Systems/CameraSystem.hpp
@@ -38,8 +38,8 @@ public:
 	{
 		if (_filter.getCollection().size() == 0)
 			return;
-		auto mousePos = _scene->getEngine().getInstance<Input>().getMousePosition();
-		auto screenSize = _scene->getEngine().getInstance<IRenderContext>().getScreenSize();
+		auto mousePos = _scene->getEngine().getInstance<Input>()->getMousePosition();
+		auto screenSize = _scene->getEngine().getInstance<IRenderContext>()->getScreenSize();
 		auto cameraCpt = _filter.getCollection().begin()->get()->getComponent<Component::CameraComponent>();
 		Utils::screenPosToWorldRay(mousePos.x, mousePos.y, screenSize.x, screenSize.y, cameraCpt->lookAtTransform, cameraCpt->projection, from, to);
 	}
@@ -48,7 +48,7 @@ public:
 	{
 		if (_filter.getCollection().size() == 0)
 			return;
-		auto screenSize = _scene->getEngine().getInstance<IRenderContext>().getScreenSize();
+		auto screenSize = _scene->getEngine().getInstance<IRenderContext>()->getScreenSize();
 		auto centerPos = glm::vec2(screenSize) * glm::vec2(0.5f);
 		auto cameraCpt = _filter.getCollection().begin()->get()->getComponent<Component::CameraComponent>();
 		Utils::screenPosToWorldRay(centerPos.x, centerPos.y, screenSize.x, screenSize.y, cameraCpt->lookAtTransform , cameraCpt->projection, from, to);
@@ -72,7 +72,7 @@ protected:
 		static double totalTime = 0;
 		unsigned int textureOffset = 0;
 		auto &renderer = _scene->getEngine().getInstance<Renderer>();
-		OpenGLTools::UniformBuffer *perFrameBuffer = _scene->getEngine().getInstance<Renderer>().getUniform("PerFrame");
+		OpenGLTools::UniformBuffer *perFrameBuffer = _scene->getEngine().getInstance<Renderer>()->getUniform("PerFrame");
 
 		for (auto e : _filter.getCollection())
 		{
@@ -83,10 +83,10 @@ protected:
 
 			if (skybox != nullptr)
 			{
-				OpenGLTools::Shader *s = _scene->getEngine().getInstance<Renderer>().getShader(camera->getSkyboxShader());
+				OpenGLTools::Shader *s = _scene->getEngine().getInstance<Renderer>()->getShader(camera->getSkyboxShader());
 				assert(s != NULL && "Skybox does not have a shader associated");
 
-				_scene->getEngine().getInstance<Renderer>().getUniform("cameraUniform")->setUniform("projection", camera->getProjection());
+				_scene->getEngine().getInstance<Renderer>()->getUniform("cameraUniform")->setUniform("projection", camera->getProjection());
 
 				glm::mat4 t = cameraPosition;
 				t[3][0] = 0;
@@ -94,10 +94,10 @@ protected:
 				t[3][2] = 0;
 				t[3][3] = 1;
 
-				_scene->getEngine().getInstance<Renderer>().getUniform("cameraUniform")->setUniform("view", t);
-				_scene->getEngine().getInstance<Renderer>().getUniform("cameraUniform")->flushChanges();
+				_scene->getEngine().getInstance<Renderer>()->getUniform("cameraUniform")->setUniform("view", t);
+				_scene->getEngine().getInstance<Renderer>()->getUniform("cameraUniform")->flushChanges();
 
-//				_engine.getInstance<Renderer>().getFbo().bindDrawTargets(s->getTargets(), s->getTargetsNumber());
+//				_engine.getInstance<Renderer>()->getFbo().bindDrawTargets(s->getTargets(), s->getTargetsNumber());
 
 				s->use();
 

--- a/GameEngine/GameEngine/Engine/Systems/TrackBallSystem.hpp
+++ b/GameEngine/GameEngine/Engine/Systems/TrackBallSystem.hpp
@@ -33,7 +33,7 @@ protected:
 
 	virtual void mainUpdate(double time)
 	{
-		Input			&inputs = _scene->getEngine().getInstance<Input>();
+		auto inputs = _scene->getInstance<Input>();
 
 		for (auto e : _filter.getCollection())
 		{
@@ -42,8 +42,8 @@ protected:
 
 			glm::vec3		pos;
 
-			trackBall->dist -= inputs.getMouseWheel().y * trackBall->zoomSpeed;
-			trackBall->angles -= glm::vec2((float)inputs.getMouseDelta().x / float(1000 / trackBall->rotateSpeed), -(float)inputs.getMouseDelta().y / float(1000 / trackBall->rotateSpeed));
+			trackBall->dist -= inputs->getMouseWheel().y * trackBall->zoomSpeed;
+			trackBall->angles -= glm::vec2((float)inputs->getMouseDelta().x / float(1000 / trackBall->rotateSpeed), -(float)inputs->getMouseDelta().y / float(1000 / trackBall->rotateSpeed));
 			if (abs(trackBall->dist) < 0.0001f)
 			{
 				if (trackBall->dist < 0)

--- a/GameEngine/GameEngine/Engine/Systems/TrackingCameraSystem.hpp
+++ b/GameEngine/GameEngine/Engine/Systems/TrackingCameraSystem.hpp
@@ -32,8 +32,6 @@ protected:
 
 	virtual void mainUpdate(double time)
 	{
-		Input			&inputs = _scene->getEngine().getInstance<Input>();
-
 		for (auto e : _filter.getCollection())
 		{
 			auto c = e->getComponent<Component::CameraComponent>();

--- a/GameEngine/GameEngine/Engine/Utils/PubSub.hpp
+++ b/GameEngine/GameEngine/Engine/Utils/PubSub.hpp
@@ -81,7 +81,7 @@ public:
 	template <typename F>
 	void globalSub(const PubSubKey &key, F lambda)
 	{
-		auto &collection = _manager.getCollection();
+		auto &collection = _manager->getCollection();
 		if (_callbacks.find(key) != std::end(_callbacks))
 			return;
 		auto fn = new decltype(toFn(lambda))(toFn(lambda));
@@ -130,7 +130,7 @@ public:
 	template <typename ...Args>
 	void broadCast(PubSubKey &name, Args ...args) const
 	{
-		_manager.pub(name, args...);
+		_manager->pub(name, args...);
 	}
 
 	template <typename ...Args>
@@ -161,7 +161,7 @@ public:
 		(*function)(args...);
 	}
 
-	PubSub(Manager &manager)
+	PubSub(std::shared_ptr<Manager> manager)
 		: _manager(manager)
 	{}
 
@@ -192,7 +192,7 @@ public:
 		unsubAll();
 	}
 
-	Manager &getPubSubManager()
+	std::shared_ptr<Manager> getPubSubManager()
 	{
 		return _manager;
 	}
@@ -204,7 +204,7 @@ public:
 private:
 	void removeFromGlobalCallbacks()
 	{
-		auto &collection = _manager.getCollection();
+		auto &collection = _manager->getCollection();
 		for (auto &e : _callbacks)
 		{
 			if (collection.find(e.first) == std::end(collection))
@@ -215,7 +215,7 @@ private:
 
 	void removeFromGlobalCallbacks(const PubSubKey &key)
 	{
-		auto &collection = _manager.getCollection();
+		auto &collection = _manager->getCollection();
 		if (collection.find(key) == std::end(collection))
 			return;
 		collection[key].erase(this);
@@ -234,7 +234,7 @@ private:
 	std::map<PubSubKey, Callback> _callbacks;
 	std::map<PubSubKey, std::unordered_set<PubSub*> > _subscribers;
 	std::unordered_set<PubSub*> _emitters;
-	Manager &_manager;
+	std::shared_ptr<Manager> _manager;
 };
 
 #endif    //__PUBSUB_HPP__

--- a/GameEngine/Packs/PhysicBulletPack/Components/CollisionBody.hpp
+++ b/GameEngine/Packs/PhysicBulletPack/Components/CollisionBody.hpp
@@ -54,7 +54,7 @@ namespace Component
 
 		bool init()
 		{
-			_manager = dynamic_cast<BulletCollisionManager*>(&_entity->getScene()->getEngine().getInstance<BulletCollisionManager>());
+			_manager = _entity->getScene()->getInstance<BulletCollisionManager>();
 			assert(_manager != nullptr);
 			return true;
 		}
@@ -172,7 +172,7 @@ namespace Component
 		CollisionShape shapeType;
 		std::string meshName;
 	private:
-		BulletCollisionManager *_manager;
+		std::shared_ptr<BulletCollisionManager> _manager;
 		btCollisionShape *_collisionShape;
 		btCollisionObject *_body;
 		CollisionBody(CollisionBody const &);

--- a/GameEngine/Packs/PhysicBulletPack/Components/FPController.hpp
+++ b/GameEngine/Packs/PhysicBulletPack/Components/FPController.hpp
@@ -87,6 +87,7 @@ namespace Component
 		btKinematicCharacterController *_controller;
 		btPairCachingGhostObject *_ghost;
 		btConvexShape *_shape;
+		std::shared_ptr<BulletDynamicManager> _manager;
 	};
 }
 

--- a/GameEngine/Packs/PhysicBulletPack/Components/RigidBody.hpp
+++ b/GameEngine/Packs/PhysicBulletPack/Components/RigidBody.hpp
@@ -50,7 +50,8 @@ namespace Component
 
 		void init(float _mass = 1.0f)
 		{
-			_manager = dynamic_cast<BulletDynamicManager*>(&_entity->getScene()->getEngine().getInstance<BulletCollisionManager>());
+			auto test = _entity->getScene()->getInstance<BulletCollisionManager>();
+			_manager = std::dynamic_pointer_cast<BulletDynamicManager>(_entity->getScene()->getInstance<BulletCollisionManager>());
 			assert(_manager != nullptr);
 			mass = _mass;
 		}
@@ -231,7 +232,7 @@ namespace Component
 		////
 		//////
 
-		BulletDynamicManager *_manager;
+		std::shared_ptr<BulletDynamicManager> _manager;
 		CollisionShape shapeType;
 		btScalar mass;
 		btVector3 inertia;

--- a/GameEngine/Packs/PhysicBulletPack/Systems/BulletCollisionSystem.hpp
+++ b/GameEngine/Packs/PhysicBulletPack/Systems/BulletCollisionSystem.hpp
@@ -13,12 +13,12 @@ class BulletCollisionSystem : public System
 {
 public:
 	BulletCollisionSystem(AScene *scene) : System(scene)
-		, _manager(scene->getEngine().getInstance<BulletCollisionManager>())
+		, _manager(scene->getInstance<BulletCollisionManager>())
 		, _filter(scene)
 	{}
 	virtual ~BulletCollisionSystem(){}
 private:
-	BulletCollisionManager &_manager;
+	std::shared_ptr<BulletCollisionManager> _manager;
 	EntityFilter _filter;
 
 	virtual void updateBegin(double time)
@@ -47,7 +47,7 @@ private:
 			e->computeTransformAndUpdateGraphnode();
 		}
 		// PERFORM COLLISION CHECK
-		_manager.getWorld()->performDiscreteCollisionDetection();
+		_manager->getWorld()->performDiscreteCollisionDetection();
 	}
 
 	virtual void initialize()

--- a/GameEngine/Packs/PhysicBulletPack/Systems/BulletDynamicSystem.hpp
+++ b/GameEngine/Packs/PhysicBulletPack/Systems/BulletDynamicSystem.hpp
@@ -17,12 +17,11 @@ public:
 		, _manager(nullptr)
 		, _filter(scene)
 	{
-		_manager = dynamic_cast<BulletDynamicManager*>(&_scene->getEngine().getInstance<BulletCollisionManager>());
-		assert(_manager != nullptr);
+		_manager = std::dynamic_pointer_cast<BulletDynamicManager>(_scene->getInstance<BulletCollisionManager>());
 	}
 	virtual ~BulletDynamicSystem(){}
 private:
-	BulletDynamicManager *_manager;
+	std::shared_ptr<BulletDynamicManager> _manager;
 	EntityFilter _filter;
 
 	virtual void updateBegin(double time)

--- a/GameEngine/Packs/PhysicBulletPack/Systems/CollisionAdderSystem.hpp
+++ b/GameEngine/Packs/PhysicBulletPack/Systems/CollisionAdderSystem.hpp
@@ -12,11 +12,11 @@ class CollisionAdder : public System
 {
 public:
 	CollisionAdder(AScene *scene) : System(scene)
-		, _manager(scene->getEngine().getInstance<BulletCollisionManager>())
+		, _manager(scene->getInstance<BulletCollisionManager>())
 	{}
 	virtual ~CollisionAdder(){}
 private:
-	BulletCollisionManager &_manager;
+	std::shared_ptr<BulletCollisionManager> _manager;
 	virtual void updateBegin(double time)
 	{
 	}
@@ -26,7 +26,7 @@ private:
 
 	virtual void mainUpdate(double time)
 	{
-		btDispatcher *dispatcher = _manager.getWorld()->getDispatcher();
+		btDispatcher *dispatcher = _manager->getWorld()->getDispatcher();
 		unsigned int max = dispatcher->getNumManifolds();
 		for (unsigned int i = 0; i < max; ++i)
 		{

--- a/GameEngine/Packs/PhysicBulletPack/Systems/FPControllerSystem.hpp
+++ b/GameEngine/Packs/PhysicBulletPack/Systems/FPControllerSystem.hpp
@@ -16,12 +16,12 @@ class FPControllerSystem : public System
 {
 public:
 	FPControllerSystem(AScene *scene) : System(scene)
-		, _manager(&scene->getEngine().getInstance<BulletCollisionManager>())
+		, _manager(scene->getEngine().getInstance<BulletCollisionManager>())
 		, _filter(scene)
 	{}
 	virtual ~FPControllerSystem(){}
 private:
-	BulletCollisionManager *_manager;
+	std::shared_ptr<BulletCollisionManager> _manager;
 	EntityFilter _filter;
 
 	virtual void updateBegin(double time)
@@ -37,7 +37,7 @@ private:
 		{
 			auto fp = e->getComponent<Component::FPController>();
 			updateComponent(e, fp, time);
-			auto &inputs = _scene->getEngine().getInstance<Input>();
+			auto inputs = _scene->getEngine().getInstance<Input>();
 			auto &ghost = fp->getGhost();
 			auto trans = ghost.getWorldTransform();
 
@@ -52,7 +52,7 @@ private:
 			m = glm::scale(m, scale);
 			e->setLocalTransform() = m;
 
-			float yAngle = inputs.getMouseDelta().y;
+			float yAngle = inputs->getMouseDelta().y;
 			fp->yOrientation = fp->yOrientation + yAngle * fp->rotateYSpeed;
 			if (fp->yOrientation >= 90.0f)
 				fp->yOrientation = 89.9f;
@@ -67,15 +67,15 @@ private:
 	void updateComponent(Entity &entity, std::shared_ptr<Component::FPController> fp, double time)
 	{
 			fp->resetControls();
-			auto &inputs = _scene->getEngine().getInstance<Input>();
+			auto inputs = _scene->getInstance<Input>();
 			auto &controls = fp->controls;
 			auto &keys = fp->keys;
-			auto angle = glm::vec2((float)inputs.getMouseDelta().x, (float)inputs.getMouseDelta().y);
+			auto angle = glm::vec2((float)inputs->getMouseDelta().x, (float)inputs->getMouseDelta().y);
 
 			// UPDATE KEYS
 			for (unsigned int i = 0; i < controls.size(); ++i)
 			{
-				controls[i] = inputs.getKey(keys[i]);
+				controls[i] = inputs->getKey(keys[i]);
 			}
 
 			auto &ghost = fp->getGhost();

--- a/GameEngine/Tools/AssetsConvertor/DemoScene.cpp
+++ b/GameEngine/Tools/AssetsConvertor/DemoScene.cpp
@@ -50,52 +50,52 @@ bool 			DemoScene::userStart()
 
 	// end System Test
 
-		auto &convertor = _engine.getInstance<AssetsConvertorManager>();
-		convertor.setOutputDirectory("./Assets/Serialized/");
+		auto convertor = _engine.getInstance<AssetsConvertorManager>();
+		convertor->setOutputDirectory("./Assets/Serialized/");
 
-		convertor.load("./Assets/cube/cube.obj");
-		convertor.serializeData("cube");
-		convertor.clear();
+		//convertor.load("./Assets/cube/cube.obj");
+		//convertor.serializeData("cube");
+		//convertor.clear();
 
-		convertor.load("./Assets/ball/ball.obj");
-		convertor.serializeData("ball");
-		convertor.clear();
+		//convertor.load("./Assets/ball/ball.obj");
+		//convertor.serializeData("ball");
+		//convertor.clear();
 
-		convertor.load("./Assets/galileo/galileo.obj");
-		convertor.serializeData("galileo");
-		convertor.clear();
+		//convertor.load("./Assets/galileo/galileo.obj");
+		//convertor.serializeData("galileo");
+		//convertor.clear();
 
-		convertor.load("./Assets/crytek-sponza/sponza.obj");
-		convertor.serializeData("sponza");
-		convertor.clear();
+		//convertor.load("./Assets/crytek-sponza/sponza.obj");
+		//convertor.serializeData("sponza");
+		//convertor.clear();
 
-		convertor.load("./Assets/EarthCloud.tga");
-		convertor.load("./Assets/EarthNightTexture.tga");
-		convertor.load("./Assets/EarthTexture.tga");
-		convertor.load("./Assets/EarthTextureBump.tga");
-		convertor.load("./Assets/EarthClouds.tga");
-		convertor.load("./Assets/MoonNormalMap.tga");
-		convertor.load("./Assets/MoonTexture.tga");
-		convertor.load("./Assets/SunTexture.tga");
-		convertor.load("./Assets/space.skybox");
-		convertor.serializeData("Space");
-		convertor.clear();
+		//convertor.load("./Assets/EarthCloud.tga");
+		//convertor.load("./Assets/EarthNightTexture.tga");
+		//convertor.load("./Assets/EarthTexture.tga");
+		//convertor.load("./Assets/EarthTextureBump.tga");
+		//convertor.load("./Assets/EarthClouds.tga");
+		//convertor.load("./Assets/MoonNormalMap.tga");
+		//convertor.load("./Assets/MoonTexture.tga");
+		//convertor.load("./Assets/SunTexture.tga");
+		//convertor.load("./Assets/space.skybox");
+		//convertor.serializeData("Space");
+		//convertor.clear();
 
 		//convertor.load("./Assets/museum.obj");
 		//convertor.serializeData("Museum");
 		//convertor.clear();
 
-		//convertor.load("./Assets/city/city.obj");
-		//convertor.serializeData("City");
-		//convertor.clear();
+		convertor->load("./Assets/elf/elf.obj");
+		convertor->serializeData("Elf");
+		convertor->clear();
 
 	return (true);
 }
 
 bool 			DemoScene::userUpdate(double time)
 {
-	if (_engine.getInstance<Input>().getInput(SDLK_ESCAPE) ||
-		_engine.getInstance<Input>().getInput(SDL_QUIT))
+	if (_engine.getInstance<Input>()->getInput(SDLK_ESCAPE) ||
+		_engine.getInstance<Input>()->getInput(SDL_QUIT))
 		return (false);
 	return (true);
 }

--- a/GameEngine/Tools/AssetsConvertor/Main.cpp
+++ b/GameEngine/Tools/AssetsConvertor/Main.cpp
@@ -37,12 +37,12 @@ int			main(int ac, char **av)
 		return (EXIT_FAILURE);
 
 	// add scene
-	e.getInstance<SceneManager>().addScene(new DemoScene(e), "demo");
+	e.getInstance<SceneManager>()->addScene(new DemoScene(e), "demo");
 
 	// bind scene
-	if (!e.getInstance<SceneManager>().initScene("demo"))
+	if (!e.getInstance<SceneManager>()->initScene("demo"))
 		return false;
-	e.getInstance<SceneManager>().enableScene("demo", 0);
+	e.getInstance<SceneManager>()->enableScene("demo", 0);
 
 
 	// lanch engine


### PR DESCRIPTION
Dependecies injector has been rewrited : 
It now return std::shared_ptr and not reference any more.
Depencies injectors can be linked so you can access dependencies in the parent via childs : 

If the dependence is not in the scene it'll be searched inside engine.

Closed #73 
