### PR TITLE
World editor mesh and materials

### DIFF
--- a/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
+++ b/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
@@ -212,7 +212,7 @@ namespace AGE
 		getInstance<AGE::AssetsManager>()->setAssetsDirectory("../../Assets/Serialized/");
 		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("cube/cube.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
 		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("ball/ball.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
-		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("catwoman/catwoman.sage"), { MeshInfos::Positions, MeshInfos::Normals, MeshInfos::Uvs, MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
+		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("catwoman/catwoman.sage"), { MeshInfos::Positions, MeshInfos::Normals, MeshInfos::Uvs, MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
 		//getInstance<AGE::AssetsManager>()->loadMesh(File("Broken Tower/tower.sage"), { MeshInfos::Positions, MeshInfos::Normals, MeshInfos::Uvs, MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
 		//	getInstance<AGE::AssetsManager>()->loadMesh(File("Venice/venice.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
 		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("Sponza/sponza.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");

--- a/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
+++ b/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
@@ -211,17 +211,13 @@ namespace AGE
 
 		getInstance<AGE::AssetsManager>()->setAssetsDirectory("../../Assets/Serialized/");
 		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("catwoman/catwoman.sage"), { MeshInfos::Positions, MeshInfos::Normals, MeshInfos::Uvs, MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
-		//getInstance<AGE::AssetsManager>()->loadMesh(OldFile("cube/cube.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
-		//getInstance<AGE::AssetsManager>()->loadMesh(OldFile("ball/ball.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
-		//getInstance<AGE::AssetsManager>()->loadMesh(File("Broken Tower/tower.sage"), { MeshInfos::Positions, MeshInfos::Normals, MeshInfos::Uvs, MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
-		//	getInstance<AGE::AssetsManager>()->loadMesh(File("Venice/venice.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
-		//getInstance<AGE::AssetsManager>()->loadMesh(OldFile("Sponza/sponza.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
-		//getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("cube/cube.mage"), "DEMO_SCENE_ASSETS");
-		//getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("ball/ball.mage"), "DEMO_SCENE_ASSETS");
+		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("cube/cube.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
+		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("ball/ball.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
+		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("Sponza/sponza.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
+		getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("cube/cube.mage"), "DEMO_SCENE_ASSETS");
+		getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("ball/ball.mage"), "DEMO_SCENE_ASSETS");
 		getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("catwoman/catwoman.mage"), "DEMO_SCENE_ASSETS");
-		//getInstance<AGE::AssetsManager>()->loadMaterial(File("Venice/venice.mage"), "DEMO_SCENE_ASSETS");
-		//getInstance<AGE::AssetsManager>()->loadMaterial(File("Broken Tower/tower.mage"), "DEMO_SCENE_ASSETS");
-		//getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("Sponza/sponza.mage"), "DEMO_SCENE_ASSETS");
+		getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("Sponza/sponza.mage"), "DEMO_SCENE_ASSETS");
 		//getInstance<AGE::AssetsManager>()->loadSkeleton(File("catwoman/catwoman.skage"), "DEMO_SCENE_ASSETS");
 		//getInstance<AGE::AssetsManager>()->loadAnimation(File("catwoman/catwoman-roulade.aage"), "DEMO_SCENE_ASSETS");
 
@@ -279,20 +275,18 @@ namespace AGE
 				auto &link = GLOBAL_FLOOR.getLink();
 				link.setPosition(glm::vec3(0, -0.532, 0));
 				link.setScale(glm::vec3(100, 1, 100));
-				//auto mesh = GLOBAL_FLOOR.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage"));
-				//mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("cube/cube.mage"));
-				//{
-				//	GLOBAL_SPONZA = createEntity();
-				//	auto& _l = GLOBAL_SPONZA.getLink();
-				//	//_l->setPosition(glm::vec3(-5, 0, 0));
-				//	RigidBody *rb = GLOBAL_SPONZA.addComponent<RigidBody>(0.0f);
-				//	rb->setCollisionMesh(this, GLOBAL_SPONZA, "../../Assets/Serialized/sponza/sponza_static.phage");
-				//	_l.setScale(glm::vec3(10.f));
-				//	//_l->setOrientation(glm::quat(glm::vec3(Mathematic::degreeToRadian(-90), Mathematic::degreeToRadian(90), 0)));
-				//
-				//	auto _m = GLOBAL_SPONZA.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("Sponza/sponza.sage"));
-				//	_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("Sponza/sponza.mage")));
-				//}
+				auto mesh = GLOBAL_FLOOR.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage"), getInstance<AGE::AssetsManager>()->getMaterial("cube/cube.mage"));
+				{
+					GLOBAL_SPONZA = createEntity();
+					auto& _l = GLOBAL_SPONZA.getLink();
+					//_l->setPosition(glm::vec3(-5, 0, 0));
+					RigidBody *rb = GLOBAL_SPONZA.addComponent<RigidBody>(0.0f);
+					rb->setCollisionMesh(this, GLOBAL_SPONZA, "../../Assets/Serialized/sponza/sponza_static.phage");
+					_l.setScale(glm::vec3(10.f));
+					//_l->setOrientation(glm::quat(glm::vec3(Mathematic::degreeToRadian(-90), Mathematic::degreeToRadian(90), 0)));
+				
+					auto _m = GLOBAL_SPONZA.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("Sponza/sponza.sage"), getInstance<AGE::AssetsManager>()->getMaterial(OldFile("Sponza/sponza.mage")));
+				}
 
 	{
 		GLOBAL_CATWOMAN = createEntity();
@@ -316,8 +310,7 @@ namespace AGE
 		auto &_l = e.getLink();
 		_l.setPosition(glm::vec3(i, 1.0f, i));
 		_l.setScale(glm::vec3(0.05f));
-		//auto _m = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"));
-		//_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("ball/ball.mage"));
+		auto _m = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"), getInstance<AGE::AssetsManager>()->getMaterial("ball/ball.mage"));
 		e.getLink().setPosition(glm::vec3(i, 5.0f, 0));
 		e.addComponent<PointLightComponent>()->set(glm::vec3((float)(rand() % 1000) / 1000.0f, (float)(rand() % 1000) / 1000.0f, (float)(rand() % 1000) / 1000.0f), glm::vec3(1.f, 0.1f, 0.0f));
 	}
@@ -329,8 +322,9 @@ namespace AGE
 		auto &_l = e.getLink();
 		_l.setPosition(glm::vec3(i, 1.0f, i));
 		//_l.setScale(glm::vec3(0.05f));
-		//auto _m = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"));
-		//_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("ball/ball.mage"));
+		auto _m = e.addComponent<MeshRenderer>(
+			getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage")
+			, getInstance<AGE::AssetsManager>()->getMaterial("ball/ball.mage"));
 		e.getLink().setPosition(glm::vec3(i, 5.0f, 0));
 		e.addComponent<PointLightComponent>()->set(glm::vec3((float)(rand() % 1000) / 1000.0f, (float)(rand() % 1000) / 1000.0f, (float)(rand() % 1000) / 1000.0f), glm::vec3(1.f, 0.1f, 0.0f));
 		e.getLink().attachParent(GLOBAL_LIGHTS[0].getLinkPtr());
@@ -415,14 +409,12 @@ namespace AGE
 				MeshRenderer *mesh;
 				if (i % 4 == 0)
 				{
-					//mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"));
-					//mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("ball/ball.mage")));
+					mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"), getInstance<AGE::AssetsManager>()->getMaterial(OldFile("ball/ball.mage")));
 					link.setScale(glm::vec3(0.5f));
 				}
 				else
 				{
-					//mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage"));
-					//mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("cube/cube.mage")));
+					mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage"), getInstance<AGE::AssetsManager>()->getMaterial(OldFile("cube/cube.mage")));
 				}
 
 #ifdef PHYSIC_SIMULATION

--- a/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
+++ b/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
@@ -210,18 +210,18 @@ namespace AGE
 		}
 
 		getInstance<AGE::AssetsManager>()->setAssetsDirectory("../../Assets/Serialized/");
-		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("cube/cube.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
-		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("ball/ball.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
 		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("catwoman/catwoman.sage"), { MeshInfos::Positions, MeshInfos::Normals, MeshInfos::Uvs, MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
+		//getInstance<AGE::AssetsManager>()->loadMesh(OldFile("cube/cube.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
+		//getInstance<AGE::AssetsManager>()->loadMesh(OldFile("ball/ball.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
 		//getInstance<AGE::AssetsManager>()->loadMesh(File("Broken Tower/tower.sage"), { MeshInfos::Positions, MeshInfos::Normals, MeshInfos::Uvs, MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
 		//	getInstance<AGE::AssetsManager>()->loadMesh(File("Venice/venice.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
-		getInstance<AGE::AssetsManager>()->loadMesh(OldFile("Sponza/sponza.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "DEMO_SCENE_ASSETS");
-		getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("cube/cube.mage"), "DEMO_SCENE_ASSETS");
-		getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("ball/ball.mage"), "DEMO_SCENE_ASSETS");
+		//getInstance<AGE::AssetsManager>()->loadMesh(OldFile("Sponza/sponza.sage"), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents, MeshInfos::Weights, MeshInfos::BoneIndices }, "DEMO_SCENE_ASSETS");
+		//getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("cube/cube.mage"), "DEMO_SCENE_ASSETS");
+		//getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("ball/ball.mage"), "DEMO_SCENE_ASSETS");
 		getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("catwoman/catwoman.mage"), "DEMO_SCENE_ASSETS");
 		//getInstance<AGE::AssetsManager>()->loadMaterial(File("Venice/venice.mage"), "DEMO_SCENE_ASSETS");
 		//getInstance<AGE::AssetsManager>()->loadMaterial(File("Broken Tower/tower.mage"), "DEMO_SCENE_ASSETS");
-		getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("Sponza/sponza.mage"), "DEMO_SCENE_ASSETS");
+		//getInstance<AGE::AssetsManager>()->loadMaterial(OldFile("Sponza/sponza.mage"), "DEMO_SCENE_ASSETS");
 		//getInstance<AGE::AssetsManager>()->loadSkeleton(File("catwoman/catwoman.skage"), "DEMO_SCENE_ASSETS");
 		//getInstance<AGE::AssetsManager>()->loadAnimation(File("catwoman/catwoman-roulade.aage"), "DEMO_SCENE_ASSETS");
 
@@ -279,20 +279,20 @@ namespace AGE
 				auto &link = GLOBAL_FLOOR.getLink();
 				link.setPosition(glm::vec3(0, -0.532, 0));
 				link.setScale(glm::vec3(100, 1, 100));
-				auto mesh = GLOBAL_FLOOR.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage"));
-				mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("cube/cube.mage"));
-				{
-					GLOBAL_SPONZA = createEntity();
-					auto& _l = GLOBAL_SPONZA.getLink();
-					//_l->setPosition(glm::vec3(-5, 0, 0));
-					RigidBody *rb = GLOBAL_SPONZA.addComponent<RigidBody>(0.0f);
-					rb->setCollisionMesh(this, GLOBAL_SPONZA, "../../Assets/Serialized/sponza/sponza_static.phage");
-					_l.setScale(glm::vec3(10.f));
-					//_l->setOrientation(glm::quat(glm::vec3(Mathematic::degreeToRadian(-90), Mathematic::degreeToRadian(90), 0)));
-				
-					auto _m = GLOBAL_SPONZA.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("Sponza/sponza.sage"));
-					_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("Sponza/sponza.mage")));
-				}
+				//auto mesh = GLOBAL_FLOOR.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage"));
+				//mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("cube/cube.mage"));
+				//{
+				//	GLOBAL_SPONZA = createEntity();
+				//	auto& _l = GLOBAL_SPONZA.getLink();
+				//	//_l->setPosition(glm::vec3(-5, 0, 0));
+				//	RigidBody *rb = GLOBAL_SPONZA.addComponent<RigidBody>(0.0f);
+				//	rb->setCollisionMesh(this, GLOBAL_SPONZA, "../../Assets/Serialized/sponza/sponza_static.phage");
+				//	_l.setScale(glm::vec3(10.f));
+				//	//_l->setOrientation(glm::quat(glm::vec3(Mathematic::degreeToRadian(-90), Mathematic::degreeToRadian(90), 0)));
+				//
+				//	auto _m = GLOBAL_SPONZA.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("Sponza/sponza.sage"));
+				//	_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("Sponza/sponza.mage")));
+				//}
 
 	{
 		GLOBAL_CATWOMAN = createEntity();
@@ -315,8 +315,8 @@ namespace AGE
 		auto &_l = e.getLink();
 		_l.setPosition(glm::vec3(i, 1.0f, i));
 		_l.setScale(glm::vec3(0.05f));
-		auto _m = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"));
-		_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("ball/ball.mage"));
+		//auto _m = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"));
+		//_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("ball/ball.mage"));
 		e.getLink().setPosition(glm::vec3(i, 5.0f, 0));
 		e.addComponent<PointLightComponent>()->set(glm::vec3((float)(rand() % 1000) / 1000.0f, (float)(rand() % 1000) / 1000.0f, (float)(rand() % 1000) / 1000.0f), glm::vec3(1.f, 0.1f, 0.0f));
 	}
@@ -328,8 +328,8 @@ namespace AGE
 		auto &_l = e.getLink();
 		_l.setPosition(glm::vec3(i, 1.0f, i));
 		//_l.setScale(glm::vec3(0.05f));
-		auto _m = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"));
-		_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("ball/ball.mage"));
+		//auto _m = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"));
+		//_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("ball/ball.mage"));
 		e.getLink().setPosition(glm::vec3(i, 5.0f, 0));
 		e.addComponent<PointLightComponent>()->set(glm::vec3((float)(rand() % 1000) / 1000.0f, (float)(rand() % 1000) / 1000.0f, (float)(rand() % 1000) / 1000.0f), glm::vec3(1.f, 0.1f, 0.0f));
 		e.getLink().attachParent(GLOBAL_LIGHTS[0].getLinkPtr());
@@ -414,14 +414,14 @@ namespace AGE
 				MeshRenderer *mesh;
 				if (i % 4 == 0)
 				{
-					mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"));
-					mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("ball/ball.mage")));
+					//mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("ball/ball.sage"));
+					//mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("ball/ball.mage")));
 					link.setScale(glm::vec3(0.5f));
 				}
 				else
 				{
-					mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage"));
-					mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("cube/cube.mage")));
+					//mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage"));
+					//mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("cube/cube.mage")));
 				}
 
 #ifdef PHYSIC_SIMULATION

--- a/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
+++ b/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
@@ -304,8 +304,9 @@ namespace AGE
 		_l.setOrientation(glm::quat(glm::vec3(Mathematic::degreeToRadian(-90), Mathematic::degreeToRadian(90), 0)));
 		_l.setPosition(glm::vec3(-30, 0, 0));
 		_l.setScale(glm::vec3(8.5f));
-		auto _m = GLOBAL_CATWOMAN.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("catwoman/catwoman.sage"));
-		_m->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial("catwoman/catwoman.mage"));
+		auto _m = GLOBAL_CATWOMAN.addComponent<MeshRenderer>(
+			getInstance<AGE::AssetsManager>()->getMesh("catwoman/catwoman.sage")
+			, getInstance<AGE::AssetsManager>()->getMaterial("catwoman/catwoman.mage"));
 	}
 
 	for (int i = 0; i < 1; ++i)
@@ -384,8 +385,8 @@ namespace AGE
 			link.setPosition(GLOBAL_CAMERA.getLink().getPosition() + glm::vec3(0, 0, -2) * GLOBAL_CAMERA.getLink().getOrientation());
 			link.setScale(glm::vec3(0.2f));
 			MeshRenderer *mesh;
-			mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage"));
-			mesh->setMaterial(getInstance<AGE::AssetsManager>()->getMaterial(OldFile("cube/cube.mage")));
+			mesh = e.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage")
+				, getInstance<AGE::AssetsManager>()->getMaterial(OldFile("cube/cube.mage")));
 			auto rigidBody = e.addComponent<RigidBody>(1.0f);
 			rigidBody->setCollisionShape((AScene*)(this), e, RigidBody::BOX);
 			rigidBody->getBody().setFriction(0.5f);

--- a/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
+++ b/GameEngine/EngineCoreTest/Scenes/BenchmarkScene.cpp
@@ -283,9 +283,13 @@ namespace AGE
 					RigidBody *rb = GLOBAL_SPONZA.addComponent<RigidBody>(0.0f);
 					rb->setCollisionMesh(this, GLOBAL_SPONZA, "../../Assets/Serialized/sponza/sponza_static.phage");
 					_l.setScale(glm::vec3(10.f));
-					//_l->setOrientation(glm::quat(glm::vec3(Mathematic::degreeToRadian(-90), Mathematic::degreeToRadian(90), 0)));
 				
-					auto _m = GLOBAL_SPONZA.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("Sponza/sponza.sage"), getInstance<AGE::AssetsManager>()->getMaterial(OldFile("Sponza/sponza.mage")));
+					///////@paul first we set a mesh with only 1 submesh
+					GLOBAL_SPONZA.addComponent<MeshRenderer>(getInstance<AGE::AssetsManager>()->getMesh("cube/cube.sage")
+						, getInstance<AGE::AssetsManager>()->getMaterial("cube/cube.mage"));
+					///////@paul then we replace it with a mesh with a lot of submesh
+					//GLOBAL_SPONZA.getComponent<MeshRenderer>()->setMeshAndMaterial(getInstance<AGE::AssetsManager>()->getMesh("Sponza/sponza.sage")
+					//	, getInstance<AGE::AssetsManager>()->getMaterial("Sponza/sponza.mage"));
 				}
 
 	{

--- a/GameEngine/GameEngine/Engine/Components/MeshRenderer.cpp
+++ b/GameEngine/GameEngine/Engine/Components/MeshRenderer.cpp
@@ -11,6 +11,8 @@
 #include <Threads/Tasks/ToRenderTasks.hpp>
 #ifdef EDITOR_ENABLED
 #include <imgui/imgui.h>
+#include <AssetManagement/AssetManager.hh>
+#include <Utils/Debug.hpp>
 #endif
 
 namespace AGE
@@ -27,30 +29,47 @@ namespace AGE
 	}
 
 
-	void MeshRenderer::init(AScene *scene, std::shared_ptr<AGE::MeshInstance> r /* = nullptr */)
+	void MeshRenderer::init(AScene *scene
+		, std::shared_ptr<AGE::MeshInstance> mesh /* = nullptr */
+		, std::shared_ptr<AGE::MaterialSetInstance> material /*= nullptr*/)
 	{
 		_scene = scene;
-		setMesh(r);
+		if (mesh && material)
+		{
+			setMeshAndMaterial(mesh, material);
+		}
 	}
 
 	void MeshRenderer::reset(AScene *scene)
 	{
 		if (!_key.invalid())
+		{
 			entity.getLink().unregisterOctreeObject(_key);
+		}
 		//scene->getInstance<AGE::Threads::Prepare>()->removeElement(_key);
 		_key = AGE::PrepareKey();
 	}
 
-	MeshRenderer &MeshRenderer::setMesh(const std::shared_ptr<AGE::MeshInstance> &mesh)
+	bool MeshRenderer::setMeshAndMaterial(
+		const std::shared_ptr<AGE::MeshInstance> &mesh,
+		const std::shared_ptr<AGE::MaterialSetInstance> &material)
 	{
-		if (!mesh)
-			return (*this);
-		_mesh = mesh;
+		if (!mesh || !material)
+		{
+			return false;
+		}
+		if (!_key.invalid())
+		{
+			entity.getLink().unregisterOctreeObject(_key);
+		}
+
+		//create key
 		_key = AGE::GetPrepareThread()->addMesh();
 		entity.getLink().registerOctreeObject(_key);
-		assert(!_key.invalid());
-		updateGeometry();
-		return (*this);
+
+		_mesh = mesh;
+		_material = material;
+		_updateGeometry();
 	}
 
 	std::shared_ptr<AGE::MeshInstance> MeshRenderer::getMesh()
@@ -58,26 +77,18 @@ namespace AGE
 		return _mesh;
 	}
 
-	MeshRenderer &MeshRenderer::setMaterial(const std::shared_ptr<AGE::MaterialSetInstance> &material)
-	{
-		_material = material;
-		AGE::GetPrepareThread()->getQueue()->emplaceCommand<Tasks::Render::SetMeshMaterial>(_material, _mesh);
-		updateGeometry();
-		return (*this);
-	}
-
 	std::shared_ptr<AGE::MaterialSetInstance> MeshRenderer::getMaterial()
 	{
 		return _material;
 	}
 
-
-
-	void MeshRenderer::updateGeometry()
+	void MeshRenderer::_updateGeometry()
 	{
-		assert(_scene != nullptr);
-		if (this->_mesh == nullptr || this->_material == nullptr)
+		if (_mesh == nullptr
+			|| _material == nullptr)
+		{
 			return;
+		}
 		AGE::GetPrepareThread()->updateGeometry(_key, _mesh->subMeshs);
 	}
 
@@ -88,20 +99,15 @@ namespace AGE
 		{
 			if (!_serializationInfos->mesh.empty())
 			{
-				auto mesh = _scene->getInstance<AGE::AssetsManager>()->getMesh(_serializationInfos->mesh);
-				if (mesh)
-				{
-					init(_scene, mesh);
-				}
+				auto _mesh = _scene->getInstance<AGE::AssetsManager>()->getMesh(_serializationInfos->mesh);
 			}
 			if (!_serializationInfos->material.empty())
 			{
-				auto material = _scene->getInstance<AGE::AssetsManager>()->getMaterial(_serializationInfos->material);
-				if (material)
-				{
-					setMaterial(material);
-				}
-				// todo with animations
+				auto _material = _scene->getInstance<AGE::AssetsManager>()->getMaterial(_serializationInfos->material);
+			}
+			if (_mesh && _material)
+			{
+				setMeshAndMaterial(_mesh, _material);
 			}
 		}
 	}
@@ -133,15 +139,63 @@ namespace AGE
 		}
 
 		ImGui::PushItemWidth(-1);
-		//ImGui::ListBoxHeader("##empty");
-		if (ImGui::ListBox("##empty", (int*)&selectedMeshIndex, &(meshFileList->front()), (int)(meshFileList->size())))
+		if (ImGui::ListBox("Meshs", (int*)&selectedMeshIndex, &(meshFileList->front()), (int)(meshFileList->size())))
 		{
 			selectedMeshName = (*meshFileList)[selectedMeshIndex];
 			selectedMeshPath = (*meshPathList)[selectedMeshIndex];
+
+			_mesh = scene->getInstance<AGE::AssetsManager>()->getMesh(selectedMeshPath);
+
+			if (!_mesh)
+			{
+				scene->getInstance<AGE::AssetsManager>()->loadMesh(OldFile(selectedMeshPath), { AGE::MeshInfos::Positions, AGE::MeshInfos::Normals, AGE::MeshInfos::Uvs, AGE::MeshInfos::Tangents }, "WE_MESH_LOADING");
+
+				std::size_t totalToLoad = 0;
+				std::size_t	toLoad = 0;
+				std::string loadingError;
+				do {
+					scene->getInstance<AGE::AssetsManager>()->updateLoadingChannel("WE_MESH_LOADING", totalToLoad, toLoad, loadingError);
+				} while
+					(toLoad != 0 && loadingError.size() == 0);
+			}
+			_mesh = scene->getInstance<AGE::AssetsManager>()->getMesh(selectedMeshPath);
+			AGE_ASSERT(_mesh != nullptr);
+			if (_material)
+			{
+				setMeshAndMaterial(_mesh, _material);
+			}
+		}
+		ImGui::PopItemWidth();
+		ImGui::PushItemWidth(-1);
+		if (!materialFileList->empty() && ImGui::ListBox("Material", (int*)&selectedMaterialIndex, &(materialFileList->front()), (int)(materialFileList->size())))
+		{
+			selectedMaterialName = (*materialFileList)[selectedMaterialIndex];
+			selectedMaterialPath = (*materialPathList)[selectedMaterialIndex];
+
+			_material = scene->getInstance<AGE::AssetsManager>()->getMaterial(selectedMaterialPath);
+
+			if (!_material)
+			{
+				scene->getInstance<AGE::AssetsManager>()->loadMaterial(OldFile(selectedMaterialPath), "WE_MESH_LOADING");
+
+				std::size_t totalToLoad = 0;
+				std::size_t	toLoad = 0;
+				std::string loadingError;
+				do {
+					scene->getInstance<AGE::AssetsManager>()->updateLoadingChannel("WE_MESH_LOADING", totalToLoad, toLoad, loadingError);
+				} while
+					(toLoad != 0 && loadingError.size() == 0);
+			}
+			_material = scene->getInstance<AGE::AssetsManager>()->getMaterial(selectedMaterialPath);
+			AGE_ASSERT(_material != nullptr);
+			if (_mesh)
+			{
+				setMeshAndMaterial(_mesh, _material);
+			}
 		}
 		//ImGui::ListBoxFooter();
 		ImGui::PopItemWidth();
-		//const std::string &path
+
 	}
 #endif
 }

--- a/GameEngine/GameEngine/Engine/Components/MeshRenderer.hh
+++ b/GameEngine/GameEngine/Engine/Components/MeshRenderer.hh
@@ -23,16 +23,19 @@ namespace AGE
 		MeshRenderer();
 		virtual ~MeshRenderer();
 
-		void init(AScene *, std::shared_ptr<AGE::MeshInstance> file = nullptr);
+		void init(AScene *
+			, std::shared_ptr<AGE::MeshInstance> mesh = nullptr
+			, std::shared_ptr<AGE::MaterialSetInstance> material = nullptr);
 		virtual void reset(AScene *);
 
 		template <typename Archive> void save(Archive &ar) const;
 		template <typename Archive> void load(Archive &ar);
 
 
-		MeshRenderer &setMesh(const std::shared_ptr<AGE::MeshInstance> &_mesh);
+		bool setMeshAndMaterial(
+			const std::shared_ptr<AGE::MeshInstance> &_mesh,
+			const std::shared_ptr<AGE::MaterialSetInstance> &_material);
 		std::shared_ptr<AGE::MeshInstance> getMesh();
-		MeshRenderer &setMaterial(const std::shared_ptr<AGE::MaterialSetInstance> &_mesh);
 		std::shared_ptr<AGE::MaterialSetInstance> getMaterial();
 
 #ifdef EDITOR_ENABLED
@@ -42,6 +45,12 @@ namespace AGE
 		std::string selectedMeshName = "";
 		std::string selectedMeshPath = "";
 
+		std::vector<const char*> *materialFileList = nullptr;
+		std::vector<const char*> *materialPathList = nullptr;
+		std::size_t selectedMaterialIndex = 0;
+		std::string selectedMaterialName = "";
+		std::string selectedMaterialPath = "";
+
 		virtual void editorCreate(AScene *scene);
 		virtual void editorDelete(AScene *scene);
 		virtual void editorUpdate(AScene *scene);
@@ -49,11 +58,11 @@ namespace AGE
 
 		virtual void postUnserialization(AScene *scene);
 
-		private:
-			AGE::PrepareKey _key;
-			AScene *_scene;
-			std::shared_ptr<AGE::MeshInstance> _mesh;
-			std::shared_ptr<AGE::MaterialSetInstance> _material;
+	private:
+		AGE::PrepareKey _key;
+		AScene *_scene;
+		std::shared_ptr<AGE::MeshInstance> _mesh;
+		std::shared_ptr<AGE::MaterialSetInstance> _material;
 
 		struct SerializationInfos
 		{
@@ -69,7 +78,7 @@ namespace AGE
 
 		std::unique_ptr<SerializationInfos> _serializationInfos;
 
-		void updateGeometry();
+		void _updateGeometry();
 		MeshRenderer(MeshRenderer const &) = delete;
 		MeshRenderer &operator=(MeshRenderer const &) = delete;
 	};

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomPipeline/BasicPipeline.cpp
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomPipeline/BasicPipeline.cpp
@@ -47,7 +47,7 @@ namespace AGE
 		*_programs[RENDER]->get_resource<Mat4>("projection_matrix") = infos.projection;
 		*_programs[RENDER]->get_resource<Mat4>("view_matrix") = infos.view;
 		//*_programs[RENDER]->get_resource<Mat4Array255>("bones") = &(infos.view);
-		*_programs[RENDER]->get_resource<Vec1>("skinned") = 0.0f;
+		//*_programs[RENDER]->get_resource<Vec1>("skinned") = 0.0f;
 
 		for (auto key : pipeline.keys) {
 			_rendering_list[RENDER]->render(key.properties, key.vertices, _painter_manager->get_painter(key.painter));

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomPipeline/BasicPipeline.cpp
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomPipeline/BasicPipeline.cpp
@@ -1,5 +1,7 @@
 #include <Render/Pipelining/Pipelines/CustomPipeline/BasicPipeline.hh>
 #include <Render/ProgramResources/Types/Uniform/Mat4.hh>
+#include <Render/ProgramResources/Types/Uniform/Mat4Array255.hh>
+#include <Render/ProgramResources/Types/Uniform/Vec1.hh>
 #include <Render/Program.hh>
 #include <Render/Pipelining/Render/Rendering.hh>
 #include <Render/OpenGLTask/Tasks.hh>
@@ -44,6 +46,9 @@ namespace AGE
 		_programs[RENDER]->use();
 		*_programs[RENDER]->get_resource<Mat4>("projection_matrix") = infos.projection;
 		*_programs[RENDER]->get_resource<Mat4>("view_matrix") = infos.view;
+		//*_programs[RENDER]->get_resource<Mat4Array255>("bones") = &(infos.view);
+		//*_programs[RENDER]->get_resource<Vec1>("skinned") = 0.0f;
+
 		for (auto key : pipeline.keys) {
 			_rendering_list[RENDER]->render(key.properties, key.vertices, _painter_manager->get_painter(key.painter));
 		}

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomPipeline/BasicPipeline.cpp
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomPipeline/BasicPipeline.cpp
@@ -47,7 +47,7 @@ namespace AGE
 		*_programs[RENDER]->get_resource<Mat4>("projection_matrix") = infos.projection;
 		*_programs[RENDER]->get_resource<Mat4>("view_matrix") = infos.view;
 		//*_programs[RENDER]->get_resource<Mat4Array255>("bones") = &(infos.view);
-		//*_programs[RENDER]->get_resource<Vec1>("skinned") = 0.0f;
+		*_programs[RENDER]->get_resource<Vec1>("skinned") = 0.0f;
 
 		for (auto key : pipeline.keys) {
 			_rendering_list[RENDER]->render(key.properties, key.vertices, _painter_manager->get_painter(key.painter));

--- a/GameEngine/GameEngine/Engine/Render/ProgramResources/Types/Uniform/Mat4Array255.cpp
+++ b/GameEngine/GameEngine/Engine/Render/ProgramResources/Types/Uniform/Mat4Array255.cpp
@@ -1,0 +1,59 @@
+#include <Render/ProgramResources/Types/Uniform/Mat4Array255.hh>
+#include <glm/gtc/type_ptr.hpp>
+#include <iostream>
+
+namespace AGE
+{
+	Mat4Array255::Mat4Array255(glm::mat4 *value, GLint id, std::string &&name) :
+		AProgramResources(id, std::move(name), GL_UNIFORM),
+		_value(value)
+	{
+
+	}
+
+	Mat4Array255::Mat4Array255(Mat4Array255 &&move) :
+		AProgramResources(std::move(move)),
+		_value(move._value)
+	{
+
+	}
+
+	Mat4Array255::Mat4Array255(Mat4Array255 const &copy) :
+		AProgramResources(copy),
+		_value(copy._value)
+	{
+
+	}
+
+	Mat4Array255 &Mat4Array255::operator=(glm::mat4 *m)
+	{
+		_update = false;
+		_value = m;
+		return (*this);
+	}
+
+	IProgramResources & Mat4Array255::update()
+	{
+		if (!_update) {
+			glUniformMatrix4fv(_id, 255, GL_FALSE, (GLfloat *)(glm::value_ptr(*_value)));
+			_update = true;
+		}
+		return (*this);
+	}
+
+	bool Mat4Array255::safe(size_t s) const
+	{
+		return ((size() == s) ? true : false);
+	}
+
+	size_t Mat4Array255::size() const
+	{
+		return (sizeof(type_t));
+	}
+
+	void Mat4Array255::print() const
+	{
+		std::cout << "uniform mat4 " << _name << ";";
+		std::cout << std::endl;
+	}
+}

--- a/GameEngine/GameEngine/Engine/Render/ProgramResources/Types/Uniform/Mat4Array255.hh
+++ b/GameEngine/GameEngine/Engine/Render/ProgramResources/Types/Uniform/Mat4Array255.hh
@@ -1,0 +1,31 @@
+#pragma once
+
+# include <Render/ProgramResources/AProgramResources.hh>
+# include <glm/glm.hpp>
+
+namespace AGE
+{
+	class Program;
+
+	class Mat4Array255 : public AProgramResources
+	{
+	public:
+		Mat4Array255(glm::mat4 *value, GLint id, std::string &&name);
+		Mat4Array255(Mat4Array255 &&move);
+		Mat4Array255(Mat4Array255 const &copy);
+		Mat4Array255 &operator=(Mat4Array255 const &m) = delete;
+		Mat4Array255 &operator=(glm::mat4 *value);
+
+	public:
+		virtual IProgramResources &update() override final;
+		virtual bool safe(size_t size) const override final;
+		virtual size_t size() const override final;
+		virtual void print() const override final;
+
+	public:
+		typedef glm::mat4 *type_t;
+
+	private:
+		glm::mat4 *_value;
+	};
+}

--- a/GameEngine/GameEngine/Engine/Threads/PrepareRenderThread.cpp
+++ b/GameEngine/GameEngine/Engine/Threads/PrepareRenderThread.cpp
@@ -266,6 +266,7 @@ namespace AGE
 		scene->setPointLight(color, range, id);
 	}
 
+
 	void PrepareRenderThread::_createRenderScene(AScene *scene)
 	{
 		_scenes.emplace_back(std::make_unique<RenderScene>(this, scene->getEngine(), scene));

--- a/GameEngine/GameEngine/Engine/Threads/RenderScene.cpp
+++ b/GameEngine/GameEngine/Engine/Threads/RenderScene.cpp
@@ -300,6 +300,7 @@ namespace AGE
 				added.currentNode = UNDEFINED_IDX;
 				_drawablesToMove.push_back(id);
 				added.hasMoved = true;
+				added.moveBufferIdx = _drawablesToMove.size() - 1;
 
 				added.mesh.properties = _createPropertiesContainer();
 				added.transformationProperty = _addTransformationProperty(added.mesh.properties, glm::mat4(1));

--- a/GameEngine/GameEngine/Engine/Threads/RenderThread.cpp
+++ b/GameEngine/GameEngine/Engine/Threads/RenderThread.cpp
@@ -155,31 +155,6 @@ namespace AGE
 		});
 #endif
 
-		registerCallback<Tasks::Render::SetMeshMaterial>([&](Tasks::Render::SetMeshMaterial& msg)
-		{
-//			for (auto &subMesh : msg.mesh->subMeshs)
-//			{
-//				auto vertices = paintingManager->get_painter(subMesh.painter)->get_vertices(subMesh.vertices);
-//				assert(vertices != nullptr);
-//				if (subMesh.defaultMaterialIndex >= msg.material->datas.size())
-//				{
-//					for (auto &prop : msg.material->datas[0])
-//					{
-//						prop->set_program(pipelines[0]->get_programs());
-//						vertices->add_property(prop);
-//					}
-//				}
-//				else
-//				{
-//					for (auto &prop : msg.material->datas[subMesh.defaultMaterialIndex])
-//					{
-//						prop->set_program(pipelines[0]->get_programs());
-//						vertices->add_property(prop);
-//					}
-//				}
-//			}
-		});
-
 		return true;
 	}
 

--- a/GameEngine/GameEngine/Engine/Threads/Tasks/ToRenderTasks.hpp
+++ b/GameEngine/GameEngine/Engine/Threads/Tasks/ToRenderTasks.hpp
@@ -50,19 +50,6 @@ namespace AGE
 						data(pData) {}
 			};
 
-			struct SetMeshMaterial
-			{
-				std::shared_ptr<MaterialSetInstance> material;
-				std::shared_ptr<MeshInstance> mesh;
-
-				SetMeshMaterial(std::shared_ptr<MaterialSetInstance> pMaterial,
-					std::shared_ptr<MeshInstance> pMesh) :
-					material(pMaterial),
-					mesh(pMesh)
-				{ }
-
-			};
-
 			struct RemoveMeshProperty
 			{
 				Key<Painter> meshPainter;

--- a/GameEngine/GameEngine/GameEngine.vcxproj
+++ b/GameEngine/GameEngine/GameEngine.vcxproj
@@ -126,6 +126,7 @@
     <ClCompile Include="Engine\Components\RigidBody.cpp" />
     <ClCompile Include="Engine\Context\IRenderContext.cpp" />
     <ClCompile Include="Engine\Entities\Entity.cpp" />
+    <ClCompile Include="Engine\Render\ProgramResources\Types\Uniform\Mat4Array255.cpp" />
     <ClCompile Include="Engine\Render\Properties\Properties.cpp" />
     <ClCompile Include="Engine\Render\PropertyManager.cpp" />
     <ClCompile Include="Engine\Threads\Commands\MainToPrepareCommands.cpp" />
@@ -276,6 +277,7 @@
     <ClInclude Include="Engine\Components\Light.hh" />
     <ClInclude Include="Engine\Configuration.hpp" />
     <ClInclude Include="Engine\Entities\EntityData.hh" />
+    <ClInclude Include="Engine\Render\ProgramResources\Types\Uniform\Mat4Array255.hh" />
     <ClInclude Include="Engine\Render\Properties\Properties.hh" />
     <ClInclude Include="Engine\Threads\Commands\ToRenderCommands.hpp" />
     <ClInclude Include="Engine\Threads\Commands\MainToPrepareCommands.hpp" />

--- a/GameEngine/GameEngine/GameEngine.vcxproj.filters
+++ b/GameEngine/GameEngine/GameEngine.vcxproj.filters
@@ -140,6 +140,9 @@
     <ClCompile Include="Engine\Utils\CRC32.cpp" />
     <ClCompile Include="Engine\Utils\Library.cpp" />
     <ClCompile Include="Engine\Utils\StreamBuffer.cpp" />
+    <ClCompile Include="Engine\Render\Properties\Properties.cpp" />
+    <ClCompile Include="Engine\Render\PropertyManager.cpp" />
+    <ClCompile Include="Engine\Render\ProgramResources\Types\Uniform\Mat4Array255.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Vendors\imgui\imconfig.h" />
@@ -376,6 +379,8 @@
     <ClInclude Include="Engine\Utils\Library.hpp" />
     <ClInclude Include="Engine\Utils\Visibility.hpp" />
     <ClInclude Include="Engine\Utils\StreamBuffer.hpp" />
+    <ClInclude Include="Engine\Render\Properties\Properties.hh" />
+    <ClInclude Include="Engine\Render\ProgramResources\Types\Uniform\Mat4Array255.hh" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Engine\Components\Component.hh" />

--- a/GameEngine/Shaders/test_pipeline_1.vp
+++ b/GameEngine/Shaders/test_pipeline_1.vp
@@ -1,39 +1,19 @@
 #version 430
 
-layout (location = 0) in vec4 position;
-layout (location = 1) in vec4 normal;
-layout (location = 2) in vec2 texCoord;
-layout (location = 3) in vec4 tangent;
-layout (location = 4) in vec4 blendWeight;
-layout (location = 5) in vec4 blendIndice;
+layout(location = 0) in vec4 position;
+layout(location = 1) in vec4 normal;
+layout(location = 2) in vec2 texCoord;
+layout(location = 3) in vec4 tangent;
 
 out vec4 interpolated_color;
 
 uniform mat4 projection_matrix;
 uniform mat4 view_matrix;
 uniform mat4 model_matrix;
-uniform mat4 bones[255];
-uniform float skinned;
 
 void main(void)
 {
-	vec4 newPosition = position;
-
-	if (skinned == 0.0f)
-	{
-		newPosition = blendWeight * blendIndice + tangent + vec4(texCoord.x, texCoord.y, 1.0f, 1.0f);
-	//
-	//	if (blendWeight.x > 0.0f)
-	//		newPosition = (bones[int(blendIndice.x)] * position) * blendWeight.x;
-	//	if (blendWeight.y > 0.0f)
-	//		newPosition += (bones[int(blendIndice.y)] * position) * blendWeight.y;
-	//	if (blendWeight.z > 0.0f)
-	//		newPosition += (bones[int(blendIndice.z)] * position) * blendWeight.z;
-	//	if (blendWeight.w > 0.0f)
-	//		newPosition += (bones[int(blendIndice.w)] * position) * blendWeight.w;
-	}
-
-	mat4 model_view = view_matrix * model_matrix; 
+	mat4 model_view = view_matrix * model_matrix;
 	interpolated_color = normal;
-	gl_Position = vec4(projection_matrix * model_view * newPosition);
+	gl_Position = vec4(projection_matrix * model_view * position);
 }

--- a/GameEngine/Shaders/test_pipeline_1.vp
+++ b/GameEngine/Shaders/test_pipeline_1.vp
@@ -19,12 +19,11 @@ void main(void)
 {
 	vec4 newPosition = position;
 
-	if (skinned != 0.0f)
+	if (skinned == 0.0f)
 	{
-		newPosition = vec4(0.0f);
-
-	//if (blendWeight.x > 0.0f)
-	//	newPosition = vec4(1.0f);
+		newPosition = blendWeight * blendIndice + tangent + vec4(texCoord.x, texCoord.y, 1.0f, 1.0f);
+	//
+	//	if (blendWeight.x > 0.0f)
 	//		newPosition = (bones[int(blendIndice.x)] * position) * blendWeight.x;
 	//	if (blendWeight.y > 0.0f)
 	//		newPosition += (bones[int(blendIndice.y)] * position) * blendWeight.y;

--- a/GameEngine/Shaders/test_pipeline_1.vp
+++ b/GameEngine/Shaders/test_pipeline_1.vp
@@ -4,16 +4,37 @@ layout (location = 0) in vec4 position;
 layout (location = 1) in vec4 normal;
 layout (location = 2) in vec2 texCoord;
 layout (location = 3) in vec4 tangent;
+layout (location = 4) in vec4 blendWeight;
+layout (location = 5) in vec4 blendIndice;
 
 out vec4 interpolated_color;
 
 uniform mat4 projection_matrix;
 uniform mat4 view_matrix;
 uniform mat4 model_matrix;
+uniform mat4 bones[255];
+uniform float skinned;
 
 void main(void)
 {
+	vec4 newPosition = position;
+
+	if (skinned != 0.0f)
+	{
+		newPosition = vec4(0.0f);
+
+	//if (blendWeight.x > 0.0f)
+	//	newPosition = vec4(1.0f);
+	//		newPosition = (bones[int(blendIndice.x)] * position) * blendWeight.x;
+	//	if (blendWeight.y > 0.0f)
+	//		newPosition += (bones[int(blendIndice.y)] * position) * blendWeight.y;
+	//	if (blendWeight.z > 0.0f)
+	//		newPosition += (bones[int(blendIndice.z)] * position) * blendWeight.z;
+	//	if (blendWeight.w > 0.0f)
+	//		newPosition += (bones[int(blendIndice.w)] * position) * blendWeight.w;
+	}
+
 	mat4 model_view = view_matrix * model_matrix; 
 	interpolated_color = normal;
-	gl_Position = vec4(projection_matrix * model_view * position);
+	gl_Position = vec4(projection_matrix * model_view * newPosition);
 }

--- a/GameEngine/Tools/AssetsEditor/Scenes/AssetsEditorScene.hpp
+++ b/GameEngine/Tools/AssetsEditor/Scenes/AssetsEditorScene.hpp
@@ -31,8 +31,8 @@ namespace AGE
 		static std::vector<const char *> &getCookedMeshsListFullPath() { return _cookedMeshsFullPath; }
 		static std::vector<const char *> &getCookedBulletList() { return _cookedBulletFiles; }
 		static std::vector<const char *> &getCookedBulletListFullPath() { return _cookedBulletFullPath; }
-		static std::vector<const char *> &getCookedMaterialList() { return _cookedBulletFiles; }
-		static std::vector<const char *> &getCookedMaterialListFullPath() { return _cookedBulletFullPath; }
+		static std::vector<const char *> &getCookedMaterialList() { return _cookedMaterialFiles; }
+		static std::vector<const char *> &getCookedMaterialListFullPath() { return _cookedMaterialFullPath; }
 	private:
 		static AE::Folder _raw;
 	 	static AE::Folder _cook;

--- a/GameEngine/Tools/AssetsEditor/Scenes/WorldEditorScene.cpp
+++ b/GameEngine/Tools/AssetsEditor/Scenes/WorldEditorScene.cpp
@@ -2,6 +2,18 @@
 #include <imgui\imgui.h>
 #include <Systems/EntityManager.hpp>
 #include <Systems/AssetsAndComponentRelationsSystem.hpp>
+#include <Physic/BulletDynamicManager.hpp>
+#include <AssetManagement/AssetManager.hh>
+
+#include <Components/CameraComponent.hpp>
+
+#include <Threads/ThreadManager.hpp>
+#include <Threads/RenderThread.hpp>
+#include <Threads/PrepareRenderThread.hpp>
+#include <Threads/Commands/MainToPrepareCommands.hpp>
+#include <Threads/Commands/ToRenderCommands.hpp>
+#include <Threads/Tasks/BasicTasks.hpp>
+#include <Threads/Tasks/ToRenderTasks.hpp>
 
 namespace AGE
 {
@@ -18,8 +30,17 @@ namespace AGE
 
 	bool WorldEditorScene::userStart()
 	{
+		setInstance<AGE::BulletDynamicManager, AGE::BulletCollisionManager>()->init();
+		setInstance<AssetsManager>();
+		getInstance<AGE::AssetsManager>()->setAssetsDirectory("../../Assets/Serialized/");
+
+
 		addSystem<WE::AssetsAndComponentRelationsSystem>(0);
 		addSystem<WE::EntityManager>(1);
+
+		auto camera = createEntity();
+		auto cam = camera.addComponent<CameraComponent>();
+
 		return true;
 	}
 
@@ -33,6 +54,12 @@ namespace AGE
 	{
 		ImGui::EndChild();
 		ImGui::End();
+
+		// TODO
+		AGE::GetPrepareThread()->getQueue()->emplaceCommand<AGE::Commands::MainToPrepare::PrepareDrawLists>();
+		// TODO
+		AGE::GetPrepareThread()->getQueue()->emplaceCommand<AGE::Commands::ToRender::RenderDrawLists>();
+
 		return true;
 	}
 }

--- a/GameEngine/Tools/AssetsEditor/Systems/AssetsAndComponentRelationsSystem.cpp
+++ b/GameEngine/Tools/AssetsEditor/Systems/AssetsAndComponentRelationsSystem.cpp
@@ -30,6 +30,8 @@ namespace AGE
 			{
 				e.getComponent<MeshRenderer>()->meshFileList = &AssetsEditorScene::getCookedMeshsList();
 				e.getComponent<MeshRenderer>()->meshPathList = &AssetsEditorScene::getCookedMeshsListFullPath();
+				e.getComponent<MeshRenderer>()->materialFileList = &AssetsEditorScene::getCookedMaterialList();
+				e.getComponent<MeshRenderer>()->materialPathList = &AssetsEditorScene::getCookedMaterialListFullPath();
 			}
 		}
 


### PR DESCRIPTION
Mesh renderer component method simplified. TODO send material informations to prepare render thread.

@paulbaron there is a bug I can't fix !

When
1 - we add a mesh with 1 submeshinstance (for example a cube) to a mesh renderer
2 - we replace the mesh in the mesh renderer by a mesh with a lot of submesh instance (for example sponza)

It crash in Octree "removeNode" @paulbaron see "benchmarkscene.cpp" line 290 to reproduce the bug