### PR TITLE
Documentation entity component system

### DIFF
--- a/GameEngine/Documentation/README.md
+++ b/GameEngine/Documentation/README.md
@@ -9,5 +9,5 @@ This documentation is also accessible **on our official website** : http://doc.a
 #### Create your own documentation with Doxygen
 Open a command prompt, then use cd to go into the *\Documentation\configuration* directory:  
 <code>cd "path-to-your-folder\GameEngine\Documentation\configuration"</code>.  
-Then type <code>doxygen Doxyfile</code> in order to generate all html files.  
+Then type <code>doxygen</code> in order to generate all html files.  
 The documents will be created in the *Documentation\html* directory. You should start opening the index.html file with your browser.

--- a/GameEngine/Documentation/README.md
+++ b/GameEngine/Documentation/README.md
@@ -1,0 +1,13 @@
+Documentation
+-------------
+We use Doxygen to document AGE: http://www.stack.nl/~dimitri/doxygen/download.html   
+The *configuration* file contains the Doxyfile used to generate html files, and .dox files to describe the classes. All .dox are organised with the same tree structure than the source code in order to be easier to maintain.
+
+> **Note:**
+This documentation is also accessible **on our official website** : http://doc.ageproject.fr/namespace_a_g_e.html
+
+#### Create your own documentation with Doxygen
+Open a command prompt, then use cd to go into the *\Documentation\configuration* directory:  
+<code>cd "path-to-your-folder\GameEngine\Documentation\configuration"</code>.  
+Then type <code>doxygen Doxyfile</code> in order to generate all html files.  
+The documents will be created in the *Documentation\html* directory. You should start opening the index.html file with your browser.

--- a/GameEngine/Documentation/configuration/Doxyfile
+++ b/GameEngine/Documentation/configuration/Doxyfile
@@ -1595,7 +1595,7 @@ GENERATE_LATEX         = NO
 # The default directory is: latex.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_OUTPUT           = 
+LATEX_OUTPUT           = ../latex
 
 # The LATEX_CMD_NAME tag can be used to specify the LaTeX command name to be
 # invoked.
@@ -1870,7 +1870,7 @@ GENERATE_DOCBOOK       = NO
 # The default directory is: docbook.
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
-DOCBOOK_OUTPUT         = 
+DOCBOOK_OUTPUT         = ../docbook
 
 # If the DOCBOOK_PROGRAMLISTING tag is set to YES doxygen will include the
 # program listings (including syntax highlighting and cross-referencing

--- a/GameEngine/Documentation/configuration/Doxyfile
+++ b/GameEngine/Documentation/configuration/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = C:/Users/AGE/Documents/GitHub/AGE/GameEngine/Documentation/configuration
+OUTPUT_DIRECTORY       = ../html
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -1052,7 +1052,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = C:/Users/AGE/Documents/GitHub/AGE/GameEngine/Documentation/html
+HTML_OUTPUT            = ../html
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).
@@ -1595,7 +1595,7 @@ GENERATE_LATEX         = NO
 # The default directory is: latex.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_OUTPUT           = C:/Users/AGE/Documents/GitHub/AGE/GameEngine/Documentation/LaTeX
+LATEX_OUTPUT           = 
 
 # The LATEX_CMD_NAME tag can be used to specify the LaTeX command name to be
 # invoked.
@@ -1870,7 +1870,7 @@ GENERATE_DOCBOOK       = NO
 # The default directory is: docbook.
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
-DOCBOOK_OUTPUT         = C:/Users/AGE/Documents/GitHub/AGE/GameEngine/Documentation/Docbook
+DOCBOOK_OUTPUT         = 
 
 # If the DOCBOOK_PROGRAMLISTING tag is set to YES doxygen will include the
 # program listings (including syntax highlighting and cross-referencing

--- a/GameEngine/Documentation/configuration/Entities/Entity.dox
+++ b/GameEngine/Documentation/configuration/Entities/Entity.dox
@@ -1,0 +1,56 @@
+/*!
+\class		Entity Entity.hh "Engine/Entity.hh"
+\brief		An entity
+
+\code
+			int			main(int ac, char **av)
+			{
+			}
+\endcode
+
+\fn			Entity::Entity()
+\brief		Default constructor.
+
+\fn			Entity::Entity(const Entity &o)
+\brief		Copy constructor.
+
+\fn			Entity::Entity(const Entity &&o)
+\brief		Move constructor.
+
+\fn			Entity::~Entity()
+\brief		Default destructor.
+
+\fn			Entity::Entity & operator= (const Entity &o)
+\brief		Copy assigment operator
+\return		An entity.
+ 
+\fn			bool Entity::operator== (const Entity &o) const
+\brief		Returns true if both entities have same version and id.
+\return		A boolean.
+ 
+\fn			bool Entity::operator!= (const Entity &o) const
+\brief		Returns true if both entities have different version and id.
+\return		A boolean.
+ 
+\fn			bool Entity::operator< (const Entity &o) const
+\brief		Returns true if the entity has an id lesser than the one given in parameter.
+\return		A boolean.
+ 
+\fn			bool Entity::operator<= (const Entity &o) const
+\brief		Returns true if the entity has an id lesser than or equal to the one given in parameter. 
+\return		A boolean.
+ 
+\fn			bool Entity::operator> (const Entity &o) const
+\brief		Returns true if the entity has an id greater than the one given in parameter.
+\return		A boolean.
+ 
+\fn			bool Entity::operator>= (const Entity &o) const
+\brief		Returns true if the entity has an id greater than or equal to one given in parameter.
+\return		A boolean.
+
+\fn			void Entity::removeComponent(ComponentType id)
+\brief		Remove a component from the entity.
+\param		id is the component identifier.
+\return		void
+
+*/

--- a/GameEngine/Documentation/configuration/Entities/Entity.dox
+++ b/GameEngine/Documentation/configuration/Entities/Entity.dox
@@ -1,11 +1,17 @@
 /*!
 \class		Entity Entity.hh "Engine/Entity.hh"
-\brief		An entity
+\brief		An entity is only an empty contener which takes sense thanks to its added components.
+			Its an group of data, forming a logical creation like a character, a weapon...
+			The entity is updated by an associated system each game loop run.
 
+			To instantiate an entity, use a AScene inherited classe and use its inherited method:
 \code
-			int			main(int ac, char **av)
-			{
-			}
+			auto engine = createEntity()
+\endcode
+
+			We have now an entity, we can add some components:
+\code
+			camera.getLink().setFoward(glm::vec3(0.f, 0.f, -c * time));
 \endcode
 
 \fn			Entity::Entity()

--- a/GameEngine/Documentation/configuration/Entities/Entity.dox
+++ b/GameEngine/Documentation/configuration/Entities/Entity.dox
@@ -9,7 +9,7 @@
 			auto engine = createEntity()
 \endcode
 
-			We have now an entity, we can add some components:
+\brief			We have now an entity, we can add some components:
 \code
 			camera.getLink().setFoward(glm::vec3(0.f, 0.f, -c * time));
 \endcode


### PR DESCRIPTION
Début de documentation de l'entity component system, qui s'est plus mué en de la reconfiguration de Doxygen. Des chemins en dur étaient settés, remplacés maintenant pas des chemins relatifs.