### PR TITLE
Instancied draw for shadows

### DIFF
--- a/GameEngine/Archetypes/rock-a.raw_archetype
+++ b/GameEngine/Archetypes/rock-a.raw_archetype
@@ -119,34 +119,26 @@
                     "value1": 0,
                     "value2": 0
                 },
-                "Mass": 1,
+                "Mass": 0,
                 "DiagonalInertiaTensor": {
                     "value0": 1,
                     "value1": 1,
                     "value2": 1
                 },
-                "MaxAngularVelocity": 1000000,
-                "MaxDepenetrationVelocity": 1000000,
+                "MaxAngularVelocity": 7,
+                "MaxDepenetrationVelocity": 1.0000000331813535e+032,
                 "IsAffectedByGravity": false,
                 "IsKinematic": true,
-                "CollisionDetectionMode": 1
+                "CollisionDetectionMode": 0
             },
             "AGE_CORE_PhysicsCollider": {
                 "cereal_class_version": 1,
-                "ColliderType": 0,
+                "ColliderType": 3,
                 "Material": "DefaultMaterial",
                 "IsATrigger": false,
-                "FilterGroup": 1,
-                "Center": {
-                    "value0": 0,
-                    "value1": 0,
-                    "value2": 0
-                },
-                "Size": {
-                    "value0": 3,
-                    "value1": 3,
-                    "value2": 3
-                }
+                "FilterGroup": 0,
+                "Mesh": "medievalpack/meshs/rock_a",
+                "Convex": false
             }
         }
     }

--- a/GameEngine/GameEngine.sln
+++ b/GameEngine/GameEngine.sln
@@ -256,7 +256,6 @@ Global
 		{CB955D69-5F17-4705-BE34-81FBE92E26EB}.Release|Mixed Platforms.Build.0 = Release|x64
 		{CB955D69-5F17-4705-BE34-81FBE92E26EB}.Release|Win32.ActiveCfg = Release|x64
 		{CB955D69-5F17-4705-BE34-81FBE92E26EB}.Release|x64.ActiveCfg = Release|x64
-		{CB955D69-5F17-4705-BE34-81FBE92E26EB}.Release|x64.Build.0 = Release|x64
 		{CB955D69-5F17-4705-BE34-81FBE92E26EB}.Retail|Mixed Platforms.ActiveCfg = Release|x64
 		{CB955D69-5F17-4705-BE34-81FBE92E26EB}.Retail|Mixed Platforms.Build.0 = Release|x64
 		{CB955D69-5F17-4705-BE34-81FBE92E26EB}.Retail|Win32.ActiveCfg = Release|x64
@@ -285,7 +284,6 @@ Global
 		{FAE1C65E-9000-4902-AE4F-C5786810B9FD}.Release|Mixed Platforms.Build.0 = Release|x64
 		{FAE1C65E-9000-4902-AE4F-C5786810B9FD}.Release|Win32.ActiveCfg = Release|x64
 		{FAE1C65E-9000-4902-AE4F-C5786810B9FD}.Release|x64.ActiveCfg = Release|x64
-		{FAE1C65E-9000-4902-AE4F-C5786810B9FD}.Release|x64.Build.0 = Release|x64
 		{FAE1C65E-9000-4902-AE4F-C5786810B9FD}.Retail|Mixed Platforms.ActiveCfg = Release|x64
 		{FAE1C65E-9000-4902-AE4F-C5786810B9FD}.Retail|Mixed Platforms.Build.0 = Release|x64
 		{FAE1C65E-9000-4902-AE4F-C5786810B9FD}.Retail|Win32.ActiveCfg = Release|x64
@@ -440,7 +438,6 @@ Global
 		{042DAF3E-FF50-B73C-C9A4-53AC6D3CFCEC}.Release|Mixed Platforms.Build.0 = release|x64
 		{042DAF3E-FF50-B73C-C9A4-53AC6D3CFCEC}.Release|Win32.ActiveCfg = release|x64
 		{042DAF3E-FF50-B73C-C9A4-53AC6D3CFCEC}.Release|x64.ActiveCfg = release|x64
-		{042DAF3E-FF50-B73C-C9A4-53AC6D3CFCEC}.Release|x64.Build.0 = release|x64
 		{042DAF3E-FF50-B73C-C9A4-53AC6D3CFCEC}.Retail|Mixed Platforms.ActiveCfg = release|x64
 		{042DAF3E-FF50-B73C-C9A4-53AC6D3CFCEC}.Retail|Win32.ActiveCfg = release|x64
 		{042DAF3E-FF50-B73C-C9A4-53AC6D3CFCEC}.Retail|x64.ActiveCfg = release|x64
@@ -466,7 +463,6 @@ Global
 		{49C560C2-F59E-0A40-E1D5-E0F25960F1AB}.Release|Mixed Platforms.Build.0 = release|x64
 		{49C560C2-F59E-0A40-E1D5-E0F25960F1AB}.Release|Win32.ActiveCfg = release|x64
 		{49C560C2-F59E-0A40-E1D5-E0F25960F1AB}.Release|x64.ActiveCfg = release|x64
-		{49C560C2-F59E-0A40-E1D5-E0F25960F1AB}.Release|x64.Build.0 = release|x64
 		{49C560C2-F59E-0A40-E1D5-E0F25960F1AB}.Retail|Mixed Platforms.ActiveCfg = release|x64
 		{49C560C2-F59E-0A40-E1D5-E0F25960F1AB}.Retail|Win32.ActiveCfg = release|x64
 		{49C560C2-F59E-0A40-E1D5-E0F25960F1AB}.Retail|x64.ActiveCfg = release|x64

--- a/GameEngine/GameEngine/Engine/BFC/BFCBlockManagerFactory.cpp
+++ b/GameEngine/GameEngine/Engine/BFC/BFCBlockManagerFactory.cpp
@@ -84,7 +84,7 @@ namespace AGE
 		}
 	}
 
-	void BFCBlockManagerFactory::cullOnBlock(CullableTypeID channel, LFList<BFCItem> &result, const Frustum &frustum, std::size_t blockId)
+	void BFCBlockManagerFactory::cullOnBlock(CullableTypeID channel, LFList<BFCItem> &result, const Frustum &frustum, std::size_t blockId, IBFCCullCallback *callback)
 	{
 		SCOPE_profile_cpu_function("BFC");
 
@@ -102,6 +102,10 @@ namespace AGE
 			{
 				result.push(&item);
 			}
+		}
+		if (callback)
+		{
+			(*callback)(result, blockId);
 		}
 	}
 

--- a/GameEngine/GameEngine/Engine/BFC/BFCBlockManagerFactory.hpp
+++ b/GameEngine/GameEngine/Engine/BFC/BFCBlockManagerFactory.hpp
@@ -5,8 +5,8 @@
 #include "BFCBlockManager.hpp"
 #include "BFCItemID.hpp"
 
-#include "Utils/Containers/LFList.hpp"
-#include "BFC/BFCItem.hpp"
+#include "IBFCCullCallback.hpp"
+
 
 namespace AGE
 {
@@ -24,7 +24,7 @@ namespace AGE
 		void deleteItem(const BFCCullableHandle &handle);
 		BFCItem &getItem(const BFCItemID &id);
 		void cullOnChannel(CullableTypeID channel, LFList<BFCItem> &result, const Frustum &frustum);
-		void cullOnBlock(CullableTypeID channel, LFList<BFCItem> &result, const Frustum &frustum, std::size_t blockId);
+		void cullOnBlock(CullableTypeID channel, LFList<BFCItem> &result, const Frustum &frustum, std::size_t blockId, IBFCCullCallback *callback = nullptr);
 		// return the number of block to treat (each in on job)
 		std::size_t getBlockNumberToCull(CullableTypeID channel) const;
 	private:

--- a/GameEngine/GameEngine/Engine/BFC/IBFCCullCallback.hpp
+++ b/GameEngine/GameEngine/Engine/BFC/IBFCCullCallback.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Utils/Containers/LFList.hpp"
+#include "BFC/BFCItem.hpp"
+
+namespace AGE
+{
+	class IBFCCullCallback
+	{
+	public:
+		virtual void operator()(LFList<BFCItem> &result, std::size_t blockId) = 0;
+	};
+}

--- a/GameEngine/GameEngine/Engine/Components/ArchetypeComponent.hpp
+++ b/GameEngine/GameEngine/Engine/Components/ArchetypeComponent.hpp
@@ -10,7 +10,6 @@ namespace AGE
 	// An Archetype's entity will just have this component when serialized
 	// At load, this component will be detected and the archetype's infos
 	// will fill this entity
-	START_NOT_OPTIMIZED;
 
 	struct ArchetypeComponent : public ComponentBase
 	{
@@ -57,7 +56,6 @@ namespace AGE
 		////
 		//////
 	};
-	STOP_NOT_OPTIMIZED;
 }
 
 CEREAL_CLASS_VERSION(AGE::ArchetypeComponent, 3)

--- a/GameEngine/GameEngine/Engine/Configuration.hpp
+++ b/GameEngine/GameEngine/Engine/Configuration.hpp
@@ -17,4 +17,8 @@ namespace AGE
 #define RESOLUTION_SHADOW_Y 720
 
 #define AGE_BFC
+
+// Enable if you want to activate OpenGL checks
+// like glCheckFramebufferStatus for example
+// #define AGE_CHECK_OPENGL_STATUS
 }

--- a/GameEngine/GameEngine/Engine/Graphic/DRBCameraDrawableList.cpp
+++ b/GameEngine/GameEngine/Engine/Graphic/DRBCameraDrawableList.cpp
@@ -2,6 +2,8 @@
 
 namespace AGE
 {
+	const float DRBSpotLightOccluder::invalidVector[4] = { std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest() };
+
 	CameraData::CameraData(CameraData const &cam) :
 		fxaa(cam.fxaa),
 		bloom(cam.bloom),

--- a/GameEngine/GameEngine/Engine/Graphic/DRBCameraDrawableList.hpp
+++ b/GameEngine/GameEngine/Engine/Graphic/DRBCameraDrawableList.hpp
@@ -1,17 +1,60 @@
 #pragma once
 
+#include <vector>
 #include <list>
+#include <array>
 #include <memory>
 #include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
+#include "Render/Key.hh"
+
+//@ANTHO pass in .cpp and remove max include
+
+// to remove
+#include "Utils/Debug.hpp"
 
 namespace AGE
 {
 	struct DRBData;
 	class TextureCubeMap;
+	struct DRBSpotLightOccluder
+	{
+		static const float invalidVector[4];
 
+		struct KeyHolder
+		{
+			ConcatenatedKey key; // 8
+			std::size_t     size; // 8
+		};
+		union
+		{
+			std::array<std::array<float, 4>, 4> matrix; // 64
+			KeyHolder keyHolder; // 16
+		};
+
+		DRBSpotLightOccluder()
+			: matrix({ std::array<float, 4>{ 1, 2, 3, 4 }, std::array<float, 4>{ 1, 2, 3, 4 }, std::array<float, 4>{ 1, 2, 3, 4 }, std::array<float, 4>{ 1, 2, 3, 4 } })
+		{}
+
+		DRBSpotLightOccluder(glm::mat4 &&mat)
+		{
+			memcpy(&matrix, glm::value_ptr(mat), sizeof(glm::mat4));
+		}
+		DRBSpotLightOccluder(ConcatenatedKey &&k)
+		{
+			keyHolder.key = std::move(k);
+			keyHolder.size = 0;
+			memcpy(&(matrix[3][0]), &(invalidVector), sizeof(invalidVector));
+		}
+		inline bool isKeyHolder() const
+		{
+			return (memcmp(&matrix[3][0], &invalidVector, sizeof(invalidVector)) == 0);
+		}
+	};
 	struct DRBSpotLightDrawableList
 	{
-		std::list<std::shared_ptr<DRBData>> meshs;
+		std::vector<DRBSpotLightOccluder> occluders;
 		std::shared_ptr<DRBData> spotLight;
 	};
 

--- a/GameEngine/GameEngine/Engine/Graphic/DRBMeshData.cpp
+++ b/GameEngine/GameEngine/Engine/Graphic/DRBMeshData.cpp
@@ -45,13 +45,13 @@ namespace AGE
 		_boundingBox = box;
 	}
 
-	const Key<Painter> DRBMeshData::getPainterKey() const
+	const Key<Painter> &DRBMeshData::getPainterKey() const
 	{
 		RWLockGuard(_lock, false);
 		return _painter;
 	}
 
-	const Key<Vertices> DRBMeshData::getVerticesKey() const
+	const Key<Vertices> &DRBMeshData::getVerticesKey() const
 	{
 		RWLockGuard(_lock, false);
 		return _vertices;

--- a/GameEngine/GameEngine/Engine/Graphic/DRBMeshData.hpp
+++ b/GameEngine/GameEngine/Engine/Graphic/DRBMeshData.hpp
@@ -19,8 +19,8 @@ namespace AGE
 		void setRenderMode(RenderModes mode, bool activate);
 		void setRenderModes(const RenderModeSet &modes);
 		void setAABB(const AABoundingBox &box);
-		const Key<Painter> getPainterKey() const;
-		const Key<Vertices> getVerticesKey() const;
+		const Key<Painter> &getPainterKey() const;
+		const Key<Vertices> &getVerticesKey() const;
 		bool hadRenderMode(RenderModes mode) const;
 		AABoundingBox getAABB() const;
 

--- a/GameEngine/GameEngine/Engine/Render/GeometryManagement/Data/Vertices.cpp
+++ b/GameEngine/GameEngine/Engine/Render/GeometryManagement/Data/Vertices.cpp
@@ -164,11 +164,11 @@ namespace AGE
 		if (_indices_block_memory.lock())
 		{
 			auto offset = _indices_block_memory.lock()->offset();
-			glDrawElementsInstancedBaseVertex(mode, GLsizei(_nbr_indices), GL_UNSIGNED_INT, (GLvoid *)offset, count, GLint(_offset));
+			glDrawElementsInstancedBaseVertex(mode, GLsizei(_nbr_indices), GL_UNSIGNED_INT, (GLvoid *)offset, GLsizei(count), GLint(_offset));
 		}
 		else
 		{
-			glDrawArraysInstanced(mode, (GLint)_offset, (GLsizei)_nbr_vertex, count);
+			glDrawArraysInstanced(mode, (GLint)_offset, (GLsizei)_nbr_vertex, GLsizei(count));
 		}
 	}
 

--- a/GameEngine/GameEngine/Engine/Render/Key.hh
+++ b/GameEngine/GameEngine/Engine/Render/Key.hh
@@ -77,7 +77,7 @@ namespace AGE
 	template <typename T1, typename T2>
 	static inline ConcatenatedKey ConcatenateKey(const Key<T1> &top, const Key<T2> &bottom)
 	{
-		return (uint64_t)(top << 32) | (uint64_t)(bottom);
+		return ((uint64_t)(top.getId()) << 32) | (uint64_t)(bottom.getId());
 	}
 
 	template <typename T1, typename T2>

--- a/GameEngine/GameEngine/Engine/Render/Key.hh
+++ b/GameEngine/GameEngine/Engine/Render/Key.hh
@@ -1,12 +1,10 @@
 #pragma once
-
-#include <iostream>
-#include <queue>
 #include <cstdint>
-#include <vector>
 
 namespace AGE
 {
+	typedef uint64_t ConcatenatedKey;
+
 	template <typename TYPE>
 	class Key
 	{
@@ -14,21 +12,21 @@ namespace AGE
 		Key();
 
 	public:
-		static Key<TYPE> createKey(size_t index);
+		static Key<TYPE> createKey(uint32_t index);
 
 	public:
-		size_t getId() const;
+		uint32_t getId() const;
 		bool isValid() const;
 		void destroy();
 		bool operator==(const Key &o);
 		bool operator!=(const Key &o);
 	private:
-		size_t _id;
-		explicit Key(size_t id);
+		uint32_t _id;
+		explicit Key(uint32_t id);
 	};
 
 	template <typename type_t>
-	inline size_t Key<type_t>::getId() const
+	inline uint32_t Key<type_t>::getId() const
 	{
 		return (_id);
 	}
@@ -46,13 +44,13 @@ namespace AGE
 	}
 
 	template <typename type_t>
-	inline Key<type_t>::Key(size_t id)
+	inline Key<type_t>::Key(uint32_t id)
 	{
 		_id = id;
 	}
 
 	template <typename type_t>
-	inline Key<type_t> Key<type_t>::createKey(size_t index)
+	inline Key<type_t> Key<type_t>::createKey(uint32_t index)
 	{
 		return (Key<type_t>(index));
 	}
@@ -74,5 +72,18 @@ namespace AGE
 	inline bool Key<type_t>::operator!=(const Key<type_t> &o)
 	{
 		return (_id != o._id);
+	}
+
+	template <typename T1, typename T2>
+	static inline ConcatenatedKey ConcatenateKey(const Key<T1> &top, const Key<T2> &bottom)
+	{
+		return (uint64_t)(top << 32) | (uint64_t)(bottom);
+	}
+
+	template <typename T1, typename T2>
+	static inline void UnConcatenateKey(ConcatenatedKey concatenatedKey, Key<T1> &topResult, Key<T2> &bottomResult)
+	{
+		topResult = Key<T1>::createKey((uint32_t)(concatenatedKey >> 32));
+		bottomResult = Key<T2>::createKey((uint32_t)(concatenatedKey));
 	}
 }

--- a/GameEngine/GameEngine/Engine/Render/Key.hh
+++ b/GameEngine/GameEngine/Engine/Render/Key.hh
@@ -20,7 +20,8 @@ namespace AGE
 		size_t getId() const;
 		bool isValid() const;
 		void destroy();
-
+		bool operator==(const Key &o);
+		bool operator!=(const Key &o);
 	private:
 		size_t _id;
 		explicit Key(size_t id);
@@ -61,5 +62,17 @@ namespace AGE
 		_id(-1)
 	{
 
+	}
+
+	template <typename type_t>
+	inline bool Key<type_t>::operator==(const Key<type_t> &o)
+	{
+		return (_id == o._id);
+	}
+
+	template <typename type_t>
+	inline bool Key<type_t>::operator!=(const Key<type_t> &o)
+	{
+		return (_id != o._id);
 	}
 }

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Buffer/Framebuffer.cpp
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Buffer/Framebuffer.cpp
@@ -79,10 +79,15 @@ namespace AGE
 		SCOPE_profile_cpu_function("RenderTimer");
 
 		storage.attachment(*this, attach);
-		if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+#ifdef AGE_CHECK_OPENGL_STATUS
 		{
-			AGE_ASSERT(false);
+			SCOPE_profile_cpu_i("RenderTimer", "GL debug check framebuffer status");
+			if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+			{
+				AGE_ASSERT(false);
+			}
 		}
+#endif
 		return (*this);
 	}
 

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DebugLightBillboards.cpp
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DebugLightBillboards.cpp
@@ -25,12 +25,6 @@
 #include "Render/Textures/TextureBuffer.hh"
 #include "Render/ProgramResources/Types/Uniform/Sampler/SamplerBuffer.hh"
 #include "Render/Pipelining/Pipelines/PipelineTools.hh"
-#include "glm/gtc/matrix_transform.hpp"
-
-static std::shared_ptr<AGE::TextureBuffer> g_position_buffer = nullptr;
-static const std::size_t max_matrix_instancied = 256;
-static const std::size_t sizeofMatrix = sizeof(glm::mat4);
-static const std::size_t max_instancied_billboard = max_matrix_instancied;
 
 namespace AGE
 {
@@ -67,7 +61,7 @@ namespace AGE
 		_forbidden[AGE_SKINNED] = true;
 		_forbidden[AGE_SEMI_TRANSPARENT] = true;
 
-		g_position_buffer = createRenderPassOutput<TextureBuffer>(max_instancied_billboard, GL_RGBA32F, sizeof(glm::mat4), GL_DYNAMIC_DRAW);
+		_positionBuffer = createRenderPassOutput<TextureBuffer>(_maxInstanciedBillboard, GL_RGBA32F, sizeof(glm::mat4), GL_DYNAMIC_DRAW);
 
 		_programs[PROGRAM_BUFFERING_LIGHT]->get_resource<SamplerBuffer>("model_matrix_tbo")->addInstanciedAlias("model_matrix");
 	}
@@ -100,27 +94,27 @@ namespace AGE
 
 				auto map = GetEngine()->getInstance<AssetsManager>()->getPointLightTexture();
 
-				_programs[PROGRAM_BUFFERING_LIGHT]->get_resource<SamplerBuffer>("model_matrix_tbo").set(g_position_buffer);
+				_programs[PROGRAM_BUFFERING_LIGHT]->get_resource<SamplerBuffer>("model_matrix_tbo").set(_positionBuffer);
 				_programs[PROGRAM_BUFFERING_LIGHT]->get_resource<Sampler2D>("sprite_light_map").set(map);
 
-				g_position_buffer->resetOffset();
+				_positionBuffer->resetOffset();
 				_quadPainter->instanciedDrawBegin(_programs[PROGRAM_BUFFERING_LIGHT]);
 				for (auto &pl : pointLightList)
 				{
 					_programs[PROGRAM_BUFFERING_LIGHT]->registerProperties(pl->globalProperties);
 					_programs[PROGRAM_BUFFERING_LIGHT]->updateProperties(pl->globalProperties);
-					if (g_position_buffer->isFull())
+					if (_positionBuffer->isFull())
 					{
-						g_position_buffer->sendBuffer();
-						_quadPainter->instanciedDraw(GL_TRIANGLES, _programs[PROGRAM_BUFFERING_LIGHT], _quadVertices, g_position_buffer->getOffset());
-						g_position_buffer->resetOffset();
+						_positionBuffer->sendBuffer();
+						_quadPainter->instanciedDraw(GL_TRIANGLES, _programs[PROGRAM_BUFFERING_LIGHT], _quadVertices, _positionBuffer->getOffset());
+						_positionBuffer->resetOffset();
 					}
 				}
-				if (g_position_buffer->isEmpty() == false)
+				if (_positionBuffer->isEmpty() == false)
 				{
-					g_position_buffer->sendBuffer();
-					_quadPainter->instanciedDraw(GL_TRIANGLES, _programs[PROGRAM_BUFFERING_LIGHT], _quadVertices, g_position_buffer->getOffset());
-					g_position_buffer->resetOffset();
+					_positionBuffer->sendBuffer();
+					_quadPainter->instanciedDraw(GL_TRIANGLES, _programs[PROGRAM_BUFFERING_LIGHT], _quadVertices, _positionBuffer->getOffset());
+					_positionBuffer->resetOffset();
 				}
 				_quadPainter->instanciedDrawEnd();
 			}
@@ -132,28 +126,28 @@ namespace AGE
 
 				auto map = GetEngine()->getInstance<AssetsManager>()->getSpotLightTexture();
 
-				_programs[PROGRAM_BUFFERING_LIGHT]->get_resource<SamplerBuffer>("model_matrix_tbo").set(g_position_buffer);
+				_programs[PROGRAM_BUFFERING_LIGHT]->get_resource<SamplerBuffer>("model_matrix_tbo").set(_positionBuffer);
 				_programs[PROGRAM_BUFFERING_LIGHT]->get_resource<Sampler2D>("sprite_light_map").set(map);
 
-				g_position_buffer->resetOffset();
+				_positionBuffer->resetOffset();
 				_quadPainter->instanciedDrawBegin(_programs[PROGRAM_BUFFERING_LIGHT]);
 				for (auto &pl : spotLightList)
 				{
 					auto &spotlight = (std::shared_ptr<DRBSpotLightData>&)(pl->spotLight);
 					_programs[PROGRAM_BUFFERING_LIGHT]->registerProperties(spotlight->globalProperties);
 					_programs[PROGRAM_BUFFERING_LIGHT]->updateProperties(spotlight->globalProperties);
-					if (g_position_buffer->isFull())
+					if (_positionBuffer->isFull())
 					{
-						g_position_buffer->sendBuffer();
-						_quadPainter->instanciedDraw(GL_TRIANGLES, _programs[PROGRAM_BUFFERING_LIGHT], _quadVertices, g_position_buffer->getOffset());
-						g_position_buffer->resetOffset();
+						_positionBuffer->sendBuffer();
+						_quadPainter->instanciedDraw(GL_TRIANGLES, _programs[PROGRAM_BUFFERING_LIGHT], _quadVertices, _positionBuffer->getOffset());
+						_positionBuffer->resetOffset();
 					}
 				}
-				if (g_position_buffer->isEmpty() == false)
+				if (_positionBuffer->isEmpty() == false)
 				{
-					g_position_buffer->sendBuffer();
-					_quadPainter->instanciedDraw(GL_TRIANGLES, _programs[PROGRAM_BUFFERING_LIGHT], _quadVertices, g_position_buffer->getOffset());
-					g_position_buffer->resetOffset();
+					_positionBuffer->sendBuffer();
+					_quadPainter->instanciedDraw(GL_TRIANGLES, _programs[PROGRAM_BUFFERING_LIGHT], _quadVertices, _positionBuffer->getOffset());
+					_positionBuffer->resetOffset();
 				}
 				_quadPainter->instanciedDrawEnd();
 			}

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DebugLightBillboards.hh
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DebugLightBillboards.hh
@@ -6,6 +6,7 @@
 namespace AGE
 {
 	class Texture2D;
+	class TextureBuffer;
 
 	class DebugLightBillboards : public FrameBufferRender
 	{
@@ -22,5 +23,11 @@ namespace AGE
 	private:
 		Key<Vertices> _quadVertices;
 		std::shared_ptr<Painter> _quadPainter;
+
+		std::shared_ptr<AGE::TextureBuffer> _positionBuffer = nullptr;
+		static const std::size_t _maxMatrixInstancied = 256;
+		static const std::size_t _sizeofMatrix = sizeof(glm::mat4);
+		static const std::size_t _maxInstanciedBillboard = _maxMatrixInstancied;
+
 	};
 }

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DeferredOnScreen.cpp
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DeferredOnScreen.cpp
@@ -61,7 +61,7 @@ namespace AGE
 	void DeferredOnScreen::renderPass(const DRBCameraDrawableList &infos)
 	{
 		SCOPE_profile_gpu_i("DefferedOnScreen");
-		SCOPE_profile_cpu_function("RenderTime", "DefferedOnScreen");
+		SCOPE_profile_cpu_function("RenderTime");
 		_programs[PROGRAM_SCREEN]->use();
 		_programs[PROGRAM_SCREEN]->get_resource<Sampler2D>("screen").set(_diffuseInput);
 
@@ -71,7 +71,7 @@ namespace AGE
 		OpenGLState::glDisable(GL_STENCIL_TEST);
 		{
 			SCOPE_profile_gpu_i("Overhead pipeline");
-			SCOPE_profile_cpu_function("RenderTime", "Overhead pipeline");
+			SCOPE_profile_cpu_i("RenderTime", "Overhead pipeline");
 			_programs[PROGRAM_SCREEN]->get_resource<Vec2>("resolution").set(glm::vec2(viewport.x, viewport.y));
 			_programs[PROGRAM_SCREEN]->get_resource<Vec1>("activated").set(infos.cameraInfos.data.fxaa == true ? 1.0f : 0.f);
 		}

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DeferredShadowBuffering.cpp
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DeferredShadowBuffering.cpp
@@ -114,6 +114,7 @@ namespace AGE
 		Key<Vertices> verticesKey;
 		Key<Vertices> oldVerticesKey;
 
+		glViewport(0, 0, _frame_buffer.width(), _frame_buffer.height());
 		for (auto &spotLightPtr : infos.spotLights)
 		{
 			SCOPE_profile_gpu_i("Spotlight pass");
@@ -121,7 +122,6 @@ namespace AGE
 
 			DRBSpotLightData *spotlight = (DRBSpotLightData*)(spotLightPtr->spotLight.get());
 
-			glViewport(0, 0, _frame_buffer.width(), _frame_buffer.height());
 			_frame_buffer.attachment(*(*it), GL_DEPTH_STENCIL_ATTACHMENT);
 			glClear(GL_DEPTH_BUFFER_BIT);
 			_programs[PROGRAM_BUFFERING]->registerProperties(spotlight->globalProperties);

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DeferredShadowBuffering.hh
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DeferredShadowBuffering.hh
@@ -23,7 +23,7 @@ namespace AGE
 		std::list<std::shared_ptr<Texture2D>> _depthBuffers;
 
 		std::shared_ptr<AGE::TextureBuffer> _positionBuffer = nullptr;
-		static const std::size_t _maxMatrixInstancied = 512;
+		static const std::size_t _maxMatrixInstancied = 1024;
 		static const std::size_t _sizeofMatrix = sizeof(glm::mat4);
 		static const std::size_t _maxInstanciedShadowCaster = _maxMatrixInstancied;
 	};

--- a/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DeferredShadowBuffering.hh
+++ b/GameEngine/GameEngine/Engine/Render/Pipelining/Pipelines/CustomRenderPass/DeferredShadowBuffering.hh
@@ -7,18 +7,24 @@
 namespace AGE
 {
 	class Texture2D;
+	class TextureBuffer;
 
 	class DeferredShadowBuffering : public FrameBufferRender
 	{
 	public:
 		DeferredShadowBuffering(glm::uvec2 const &screenSize, std::shared_ptr<PaintingManager> painterManager);
 		virtual ~DeferredShadowBuffering() = default;
-
+		virtual void init();
 	protected:
 		virtual void renderPass(const DRBCameraDrawableList &infos);
 
 	private:
 		std::vector<uint32_t> _depthPixels;
 		std::list<std::shared_ptr<Texture2D>> _depthBuffers;
+
+		std::shared_ptr<AGE::TextureBuffer> _positionBuffer = nullptr;
+		static const std::size_t _maxMatrixInstancied = 512;
+		static const std::size_t _sizeofMatrix = sizeof(glm::mat4);
+		static const std::size_t _maxInstanciedShadowCaster = _maxMatrixInstancied;
 	};
 }

--- a/GameEngine/GameEngine/Engine/Render/Program.hh
+++ b/GameEngine/GameEngine/Engine/Render/Program.hh
@@ -76,6 +76,8 @@ namespace AGE
 
 		void registerProperties(Properties &properties);
 		void updateProperties(Properties &properties);
+		void updateInstanciedProperties(Properties &properties);
+		void updateNonInstanciedProperties(Properties &properties);
 	private:
 		void _get_resources();
 		void _get_resource(size_t index, GLenum resource, std::string const & buffer);
@@ -86,10 +88,13 @@ namespace AGE
 			std::size_t index;
 			std::shared_ptr<IProgramResources> resource;
 			void(*updateFunction)(IProgramResources *, IProperty*) = nullptr;
-			PropertyRegister(std::size_t _index, std::shared_ptr<IProgramResources> _resource, void(*_updateFunction)(IProgramResources *, IProperty*))
+			bool instancied;
+
+			PropertyRegister(std::size_t _index, std::shared_ptr<IProgramResources> _resource, void(*_updateFunction)(IProgramResources *, IProperty*), bool _instancied)
 				: index(_index)
 				, resource(_resource)
 				, updateFunction(_updateFunction)
+				, instancied(_instancied)
 			{}
 		};
 		struct PropertiesRegister

--- a/GameEngine/GameEngine/Engine/Render/Textures/TextureBuffer.hh
+++ b/GameEngine/GameEngine/Engine/Render/Textures/TextureBuffer.hh
@@ -2,6 +2,8 @@
 
 #include <Utils/Debug.hpp>
 
+//@ANTHO pass in .cpp and remove max include
+
 namespace AGE
 {
 	class TextureBuffer
@@ -83,6 +85,7 @@ namespace AGE
 			bindBuffer();
 			glBufferSubData(GL_TEXTURE_BUFFER, 0, _size * count, data);
 		}
+
 		inline void bindBuffer()
 		{
 			AGE_ASSERT(_bufferHandle != -1);

--- a/GameEngine/GameEngine/Engine/Skinning/AnimationManager.cpp
+++ b/GameEngine/GameEngine/Engine/Skinning/AnimationManager.cpp
@@ -14,7 +14,7 @@ namespace AGE
 
 		auto instance = std::make_shared<AnimationInstance>(skeleton, animation);
 		_list.push_back(instance);
-		instance->key = Key<AnimationInstance>::createKey(_list.size() - 1);
+		instance->key = Key<AnimationInstance>::createKey((uint32_t)(_list.size() - 1));
 		return instance->key;
 	}
 

--- a/GameEngine/GameEngine/Engine/Utils/Age_Imgui.cpp
+++ b/GameEngine/GameEngine/Engine/Utils/Age_Imgui.cpp
@@ -368,7 +368,6 @@ namespace AGE
 				vbo_size = needed_vtx_size + 2000 * sizeof(ImDrawVert);
 				glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)vbo_size, NULL, GL_STREAM_DRAW);
 			}
-
 			unsigned char* vtx_data = (unsigned char*)glMapBufferRange(GL_ARRAY_BUFFER, 0, needed_vtx_size, GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
 			if (!vtx_data)
 				continue;
@@ -383,48 +382,6 @@ namespace AGE
 				idx_buffer += pcmd->ElemCount;
 			}
 		}
-
-		////// Grow our buffer according to what we need
-		////size_t total_vtx_count = 0;
-		////for (int n = 0; n < cmd_lists.size(); n++)
-		////	total_vtx_count += cmd_lists[n].vtx_buffer.size();
-		////glBindBuffer(GL_ARRAY_BUFFER, vbo_handle);
-		////size_t neededBufferSize = total_vtx_count * sizeof(ImDrawVert);
-		////if (neededBufferSize > vbo_max_size)
-		////{
-		////	vbo_max_size = neededBufferSize + 5000;  // Grow buffer
-		////	glBufferData(GL_ARRAY_BUFFER, vbo_max_size, NULL, GL_STREAM_DRAW);
-		////}
-
-		////// Copy and convert all vertices into a single contiguous buffer
-		////unsigned char* buffer_data = (unsigned char*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
-		////if (!buffer_data)
-		////	return;
-		////for (int n = 0; n < cmd_lists.size(); n++)
-		////{
-		////	auto &cmd_list = cmd_lists[n];
-		////	memcpy(buffer_data, &cmd_list.vtx_buffer[0], cmd_list.vtx_buffer.size() * sizeof(ImDrawVert));
-		////	buffer_data += cmd_list.vtx_buffer.size() * sizeof(ImDrawVert);
-		////}
-		////glUnmapBuffer(GL_ARRAY_BUFFER);
-		////glBindBuffer(GL_ARRAY_BUFFER, 0);
-		////glBindVertexArray(vao_handle);
-
-		////int cmd_offset = 0;
-		////for (int n = 0; n < cmd_lists.size(); n++)
-		////{
-		////	SCOPE_profile_cpu_i("RenderTimer", "Render ImGui command list");
-		////	auto &cmd_list = cmd_lists[n];
-		////	int vtx_offset = cmd_offset;
-		////	auto &pcmd_end = std::end(cmd_list.commands);
-		////	for (auto &pcmd = std::begin(cmd_list.commands); pcmd != pcmd_end; pcmd++)
-		////	{
-		////		glScissor((int)pcmd->ClipRect.x, (int)(height - pcmd->ClipRect.w), (int)(pcmd->ClipRect.z - pcmd->ClipRect.x), (int)(pcmd->ClipRect.w - pcmd->ClipRect.y));
-		////		//glDrawElements(GL_TRIANGLES, pcmd->ElemCount, GL_UNSIGNED_SHORT, );
-		////		vtx_offset += pcmd->vtx_count;
-		////	}
-		////	cmd_offset = vtx_offset;
-		////}
 
 		// Restore modified state
 		glBindVertexArray(0);

--- a/GameEngine/GameEngine/Engine/Utils/Age_Imgui.hpp
+++ b/GameEngine/GameEngine/Engine/Utils/Age_Imgui.hpp
@@ -74,30 +74,5 @@ namespace AGE
 		static void renderDrawLists(ImDrawData* draw_data);
 		static void initShader(int *pid, int *vert, int *frag, const char *vs, const char *fs);
 		void renderThreadRenderFn(const std::vector<Age_ImDrawList> &cmd_lists);
-
-		template<typename T>
-		static unsigned int stream(GLenum target, unsigned int vbo, unsigned int *vbo_cursor, unsigned int *vbo_size, T *start, int elementCount)
-		{
-			unsigned int bytes = sizeof(T) *elementCount;
-			unsigned int aligned = bytes + bytes % 64; //align memory
-
-			glBindBuffer(target, vbo);
-			//If there's not enough space left, orphan the buffer object, create a new one and start writing
-			if (vbo_cursor[0] + aligned > vbo_size[0])
-			{
-				assert(aligned < vbo_size[0]);
-				glBufferData(target, vbo_size[0], NULL, GL_DYNAMIC_DRAW);
-				vbo_cursor[0] = 0;
-			}
-
-			void* mapped = glMapBufferRange(target, vbo_cursor[0], aligned, GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
-
-			memcpy(mapped, start, bytes);
-			vbo_cursor[0] += aligned;
-
-			glUnmapBuffer(target);
-			return vbo_cursor[0] - aligned; //return the offset we use for glVertexAttribPointer call
-		}
-
 	};
 }

--- a/GameEngine/GameEngine/GameEngine.vcxproj
+++ b/GameEngine/GameEngine/GameEngine.vcxproj
@@ -540,6 +540,7 @@
     <ClInclude Include="..\Vendors\imgui\imconfig.h" />
     <ClInclude Include="..\Vendors\imgui\imgui.h" />
     <ClInclude Include="..\Vendors\imgui\stb_textedit.h" />
+    <ClInclude Include="Engine\BFC\IBFCCullCallback.hpp" />
     <ClInclude Include="Engine\Components\FPSCharacter.hh" />
     <ClInclude Include="Engine\Physics\CharacterControllerInterface.hh" />
     <ClInclude Include="Engine\Render\OcclusionTools\OcclusionOptions.hpp" />

--- a/GameEngine/Shaders/deferred_shading/deferred_shading_get_shadow_buffer.vp
+++ b/GameEngine/Shaders/deferred_shading/deferred_shading_get_shadow_buffer.vp
@@ -3,9 +3,16 @@
 layout (location = 0) in vec3 position;
 
 uniform mat4 light_matrix;
-uniform mat4 model_matrix;
+uniform samplerBuffer model_matrix_tbo;
 
 void main()
 {
+	vec4 col1 = texelFetch(model_matrix_tbo, gl_InstanceID * 4);
+	vec4 col2 = texelFetch(model_matrix_tbo, gl_InstanceID * 4 + 1);
+	vec4 col3 = texelFetch(model_matrix_tbo, gl_InstanceID * 4 + 2);
+	vec4 col4 = texelFetch(model_matrix_tbo, gl_InstanceID * 4 + 3);
+	// Now assemble the four columns into a matrix.
+	mat4 model_matrix = mat4(col1, col2, col3, col4);
+
 	gl_Position = light_matrix * model_matrix * vec4(position, 1.f);
 }

--- a/GameEngine/Tools/AssetsEditor/Convertor/ImageLoader.cpp
+++ b/GameEngine/Tools/AssetsEditor/Convertor/ImageLoader.cpp
@@ -21,7 +21,6 @@
 
 namespace AGE
 {
-	START_NOT_OPTIMIZED;
 	bool ImageLoader::save(std::shared_ptr<CookingTask> cookingTask)
 	{
 #if USE_MICROSOFT_LIB
@@ -243,7 +242,6 @@ namespace AGE
 		Singleton<AGE::AE::ConvertorStatusManager>::getInstance()->PopTask(tid);
 		return true;
 	}
-	STOP_NOT_OPTIMIZED;
 
 	bool ImageLoader::load(std::shared_ptr<CookingTask> cookingTask)
 	{

--- a/GameEngine/Tools/AssetsEditor/Saves/medieval.raw_scene
+++ b/GameEngine/Tools/AssetsEditor/Saves/medieval.raw_scene
@@ -55,7 +55,7 @@
                 "value": 13917482855567903631
             }
         ],
-        "entityNumber": 296,
+        "entityNumber": 297,
         "Entity_0": {
             "cereal_class_version": 0,
             "link": {
@@ -23344,9 +23344,9 @@
         "Entity_289": {
             "link": {
                 "Position": {
-                    "value0": 12,
-                    "value1": 1,
-                    "value2": 12
+                    "value0": -7.5,
+                    "value1": 0.5,
+                    "value2": 5
                 },
                 "Scale": {
                     "value0": 3,
@@ -23584,9 +23584,9 @@
         "Entity_295": {
             "link": {
                 "Position": {
-                    "value0": -4.9594106674194336,
-                    "value1": 2.225297212600708,
-                    "value2": 3.7658936977386475
+                    "value0": -6.4516124725341797,
+                    "value1": 2.3995227813720703,
+                    "value2": -2.6443696022033691
                 },
                 "Scale": {
                     "value0": 1,
@@ -23594,10 +23594,10 @@
                     "value2": 1
                 },
                 "Orientation": {
-                    "value0": 0.025445818901062012,
-                    "value1": -0.52925223112106323,
-                    "value2": 0.015882430598139763,
-                    "value3": 0.84793418645858765
+                    "value0": 0.093618594110012054,
+                    "value1": 0.071619980037212372,
+                    "value2": -0.0067521878518164158,
+                    "value3": 0.99300587177276611
                 }
             },
             "children": [],
@@ -23618,6 +23618,83 @@
             },
             "AGE_CORE_EntityRepresentationComponent": {
                 "name": "freefly-camera-Copy-Copy"
+            }
+        },
+        "Entity_296": {
+            "link": {
+                "Position": {
+                    "value0": 0,
+                    "value1": 0,
+                    "value2": 6.1999998092651367
+                },
+                "Scale": {
+                    "value0": 20,
+                    "value1": 14,
+                    "value2": 1
+                },
+                "Orientation": {
+                    "value0": 0,
+                    "value1": 0,
+                    "value2": 0,
+                    "value3": 1
+                }
+            },
+            "children": [],
+            "flags": 0,
+            "components_number": [
+                0,
+                2,
+                9
+            ],
+            "archetypesDependency": [],
+            "AGE_CORE_EntityRepresentationComponent": {
+                "name": "fake wall"
+            },
+            "AGE_CORE_RigidBody": {
+                "AngularDrag": 0.05000000074505806,
+                "AngularVelocity": {
+                    "value0": 0,
+                    "value1": 0,
+                    "value2": 0
+                },
+                "CenterOfMass": {
+                    "value0": 0,
+                    "value1": 0,
+                    "value2": 0
+                },
+                "LinearDrag": 0,
+                "LinearVelocity": {
+                    "value0": 0,
+                    "value1": 0,
+                    "value2": 0
+                },
+                "Mass": 1,
+                "DiagonalInertiaTensor": {
+                    "value0": 1,
+                    "value1": 1,
+                    "value2": 1
+                },
+                "MaxAngularVelocity": 1000000,
+                "MaxDepenetrationVelocity": 1000000,
+                "IsAffectedByGravity": false,
+                "IsKinematic": true,
+                "CollisionDetectionMode": 1
+            },
+            "AGE_CORE_PhysicsCollider": {
+                "ColliderType": 0,
+                "Material": "DefaultMaterial",
+                "IsATrigger": false,
+                "FilterGroup": 1,
+                "Center": {
+                    "value0": 0,
+                    "value1": 0,
+                    "value2": 0
+                },
+                "Size": {
+                    "value0": 20,
+                    "value1": 14,
+                    "value2": 1
+                }
             }
         }
     }


### PR DESCRIPTION
- Les clefs `Key<T>` sont passées en 32bits
- La billboard pass a été cleané
- Des options d'update ont été ajouté pour les shaders et properties `instanciedUpdate`, `nonInstanciedUpdate`, `update` (all).
- Un define a été ajouté dans `Configuration.hpp` pour encapsuler les appels OpenGL de debug qui sucent des perfs
- 2 clefs `Key<T>` peuvent etre concaténées dans un `int64`
- Les shadow caster sont draw en instancied. Ils sont triés de manière asynchrone au moment du culling (le culling prends un peu plus de temps, mais il reste plein de place pour l'optimisation)

#### Perfs gagnées (sur le renderthread en release)

Medieval : 6.274 millis -> 3.673 millis = **-2.601 millis**
Spotlights : 1.130 millis -> 0.333 millis = **-0.797 millis**